### PR TITLE
fix for retina screenshots

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,7 +76,8 @@ module.exports = {
                             quality: 80,
                             withWebp: true,
                             linkImagesToOriginal: false,
-                            showCaptions: true
+                            showCaptions: true,
+                            sizeByPixelDensity: true
                         }
                     },
                     {


### PR DESCRIPTION
Don't require authors to modify the image dpi value and size them properly, just like GitHub does