### PR TITLE
Revised the Tools & Examples page

### DIFF
--- a/content/concepts/components.md
+++ b/content/concepts/components.md
@@ -55,7 +55,7 @@ OceanDB is an off-chain database for storing metadata about data assets.
 <repo name="oceandb-bigchaindb-driver"></repo>
 <repo name="oceandb-elasticsearch-driver"></repo>
 
-These drivers are extended from a high-level module implementing OceanDB functions.  You can create your own plugins based on its abstracted interface:
+These drivers are extended from a high-level module implementing OceanDB functions. You can create your own plugins based on its abstracted interface:
 
 <repo name="oceandb-driver-interface"></repo>
 

--- a/content/concepts/tools.md
+++ b/content/concepts/tools.md
@@ -3,21 +3,22 @@ title: Tools & Examples
 description: Tools and examples for developing with Ocean Protocol.
 ---
 
-The setup & tutorials sections have some examples to get you started.
+The Setup & Tutorials sections have some examples to get you started.
 
 - [Setup: Quick Start](/setup/quickstart/)
 - [Tutorials: Introduction](/tutorials/introduction/)
 
 ## Tools
 
-Data science tools:
-
-<repo name="mantaray"></repo>
-
-<repo name="nautilina"></repo>
+Coming soon!
 
 ## Examples
 
-JavaScript examples for working with the [🦑 squid-js](https://github.com/oceanprotocol/squid-js) library:
+Examples of using the [🦑 squid-py](https://github.com/oceanprotocol/squid-js) Python library:
 
+<repo name="mantaray"></repo>
+
+Examples of using the [🦑 squid-js](https://github.com/oceanprotocol/squid-js) JavaScript library:
+
+<repo name="pleuston"></repo>
 <repo name="tuna"></repo>


### PR DESCRIPTION
- Removed `nautilina` repo because it won't be updated and is probably already all wrong.
- The stuff in the `mantaray` repo is more examples than tools.
- The `pleuston` repo is an example of using `squid-js` so I added that.
- The small change to `components.md` was made by `npm run format`