### PR TITLE
Add email address re/ running an authority node

### DIFF
--- a/content/setup/keeper.md
+++ b/content/setup/keeper.md
@@ -6,7 +6,7 @@ description: How to Run a Keeper node in the Ocean network.
 The Ocean Protocol v0.9 (Trilobite) Testnet is an Ethereum [Proof-of-Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains) where all the nodes (Keeper nodes) are running [Parity Ethereum](https://www.parity.io/ethereum/).
 There are two kinds of Keeper nodes in the Trilobite Testnet: authority nodes (voting nodes) and user nodes (non-voting nodes).
 
-Authority nodes have a say in determining which transactions are valid. _In the Trilobite Testnet_, the authority nodes are run by BigchainDB GmbH and its partners. If you're interested in running an authority node in the Trilobite Testnet, then email <a href="mailto:contact@oceanprotocol.com">contact@oceanprotocol.com</a>.
+Authority nodes have a say in determining which transactions are valid. _In the Trilobite Testnet_, the authority nodes are run by BigchainDB GmbH and its partners. If you're interested in running an authority node in the Trilobite Testnet, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
 
 Anyone can run a user node. It will stay in sync with the other nodes in the Trilobite Testnet, it just won't have a say on whether transactions are valid.
 Marketplaces and publishers should run user nodes.


### PR DESCRIPTION
I didn't want to put the email address of any specific person. The recipients of email sent to contact@oceanprotocol.com should know where to route an email asking about running an authority node in the Trilobite Testnet.