### PR TITLE
Fix the terminology as per issue #55

### DIFF
--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -3,25 +3,29 @@ title: Terminology
 description: Terminology specific to Ocean Protocol.
 ---
 
-## Asset (or Data Asset)
+## Asset or Data Asset
 
 A data set or data service.
 
-## Data Owner or Service Provider
+## Data Owner or Data Service Provider
 
 Someone who has assets that they want to sell (or give away freely). An example is an almond distributor with 30 years of data about almond sales.
 
+Note: Initially, most data owners or data service providers will also be the publishers of their own assets.
+
 ## Publisher
 
-A service which mediates access to assets on behalf of data owners or service providers.
+A service which mediates access to assets on behalf of data owners or data service providers.
+
+Note: Initially, most publishers will also be the owners of the data assets they publish.
 
 ## Consumer
 
 Someone who wants assets. An example is a data scientist working at an economic think tank.
 
-## Marketplace
+## Marketplace or Tribe
 
-A service where publishers can list what assets they have, and consumers can see what's available then buy it (or get it for free). The Ocean network supports many marketplaces.
+A service where publishers can list what assets they have, and consumers can see what's available then buy it (or get it for free). The Ocean network supports many marketplaces/tribes.
 
 ## More Terminology
 


### PR DESCRIPTION
I added some notes about how, initially, publishers will also be the owners of the assets they publish. I didn't want to make it seem like the two will always be combined, so I didn't delete the definition of a "Publisher."

Included "Tribes" as a synonym of Marketplaces.

Changed "Data Owner or Service Provider" to "Data Owner or Data Service Provider", in case it wasn't clear that "Data" was also modifying "Service Provider."

Resolves #55 