### PR TITLE
Remove all refs to the /concepts/squid/ page

### DIFF
--- a/data/repositories.yml
+++ b/data/repositories.yml
@@ -16,17 +16,8 @@
 - group: Libraries
   items:
     - name: squid-js
-      links:
-        - name: API reference
-          url: /concepts/squid/
     - name: squid-py
-      links:
-        - name: API reference
-          url: /concepts/squid/
     - name: squid-java
-      links:
-        - name: API reference
-          url: /concepts/squid/
 
 - group: OceanDB
   items:

--- a/data/sidebars/concepts.yml
+++ b/data/sidebars/concepts.yml
@@ -13,8 +13,6 @@
   items:
     - title: Overview
       link: /concepts/architecture/
-    - title: Squid
-      link: /concepts/squid/
     - title: Secret Store
       link: /concepts/secret-store/
     - title: Computing Services


### PR DESCRIPTION
because we're removing that page from the docs site in https://github.com/oceanprotocol/dev-ocean/pull/95

