### PR TITLE
filter out API references link from main menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -39,15 +39,20 @@ const Header = () => (
                         </Link>
 
                         <nav className={styles.headerMenu}>
-                            {sections.map(({ node }) => (
-                                <Link
-                                    key={node.title}
-                                    to={node.link}
-                                    className={styles.section}
-                                >
-                                    {node.title}
-                                </Link>
-                            ))}
+                            {sections
+                                .filter(
+                                    ({ node }) =>
+                                        node.title !== 'API References'
+                                )
+                                .map(({ node }) => (
+                                    <Link
+                                        key={node.title}
+                                        to={node.link}
+                                        className={styles.section}
+                                    >
+                                        {node.title}
+                                    </Link>
+                                ))}
                         </nav>
                     </div>
                 </header>


### PR DESCRIPTION
we don't want this to show up right now, since it links to nothing, or more precisely `null`