### PR TITLE
add title to placeholder tutorials

### DIFF
--- a/content/tutorials/get-use-compute-service.md
+++ b/content/tutorials/get-use-compute-service.md
@@ -1,0 +1,3 @@
+---
+title: Get & Use a Compute Service
+---

--- a/content/tutorials/get-use-data-set.md
+++ b/content/tutorials/get-use-data-set.md
@@ -1,0 +1,3 @@
+---
+title: Get & Use a Data Set
+---

--- a/content/tutorials/publish-compute-service.md
+++ b/content/tutorials/publish-compute-service.md
@@ -1,0 +1,3 @@
+---
+title: Publish a Compute Service
+---

--- a/content/tutorials/publish-data-set.md
+++ b/content/tutorials/publish-data-set.md
@@ -1,0 +1,3 @@
+---
+title: Publish a Data Set
+---


### PR DESCRIPTION
So it doesn't look so empty and if we title them in sidebar there's no reason to not include the page title.