### PR TITLE
Rename Trilobite/Ocean POA Testnet to Nile Testnet

### DIFF
--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -9,15 +9,17 @@ You can test an Ocean Protocol application (such as a marketplace) against some 
 
 The [Kovan Testnet](https://github.com/kovan-testnet/proposal) (or just "Kovan") is a public Ethereum testnet operated by members of the Ethereum community. The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-contracts) (smart contracts) are deployed there.
 
-Moreover, there is a [Secret Store](/concepts/components/#secret-store) operated by the Ocean Protocol Foundation which is connected to the Kovan Testnet: the Ocean Secret Store for Kovan.
+Moreover, there is a [Secret Store](/concepts/components/#secret-store) operated by the Ocean Protocol Foundation which is connected to the Kovan Testnet.
 
-## Ocean Testnet
+## Nile Testnet
 
-The Ocean Testnet (also called the Ocean POA Testnet) is similar to the Kovan Testnet, except all the nodes are operated by the Ocean Protocol Foundation. The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-contracts) (smart contracts) are deployed there.
+_Formerly called the Ocean POA Tesnet._
 
-Moreover, there is a [Secret Store](/concepts/components/#secret-store) operated by the Ocean Protocol Foundation which is connected to the Ocean Testnet: the Ocean Secret Store.
+The Nile Testnet is similar to the Kovan Testnet, except all the nodes are operated by the Ocean Protocol Foundation. The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-contracts) (smart contracts) are deployed there.
+
+Moreover, there is a [Secret Store](/concepts/components/#secret-store) operated by the Ocean Protocol Foundation which is connected to the Nile Testnet.
 
 ## Technical Details about the Public Testnets
 
-- [Details about the Ocean Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/secret-store-cluster.md) (which is called the "Parity Secret Store Cluster" on that page).
+- [Details about the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/secret-store-cluster.md) (which is called the "Parity Secret Store Cluster" on that page).
 - [Addresses of the keeper contracts](https://github.com/oceanprotocol/keeper-contracts#testnet-deployment) (smart contracts) deployed in the public testnets (and more).

--- a/content/setup/keeper.md
+++ b/content/setup/keeper.md
@@ -3,11 +3,11 @@ title: Run a Keeper
 description: How to Run a Keeper node in the Ocean network.
 ---
 
-The Ocean Protocol v0.9 (Trilobite) Testnet is an Ethereum [Proof-of-Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains) where all the nodes (Keeper nodes) are running [Parity Ethereum](https://www.parity.io/ethereum/).
-There are two kinds of Keeper nodes in the Trilobite Testnet: authority nodes (voting nodes) and user nodes (non-voting nodes).
+The Nile Testnet is an Ethereum [Proof-of-Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains) where all the nodes (Keeper nodes) are running [Parity Ethereum](https://www.parity.io/ethereum/).
+There are two kinds of Keeper nodes in the Nile Testnet: authority nodes (voting nodes) and user nodes (non-voting nodes).
 
-Authority nodes have a say in determining which transactions are valid. _In the Trilobite Testnet_, the authority nodes are run by BigchainDB GmbH and its partners. If you're interested in running an authority node in the Trilobite Testnet, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
+Authority nodes have a say in determining which transactions are valid. In the Nile Testnet, the authority nodes are run by BigchainDB GmbH and its partners. If you're interested in running an authority node in the Nile Testnet, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
 
-Anyone can run a user node. It will stay in sync with the other nodes in the Trilobite Testnet, it just won't have a say on whether transactions are valid.
+Anyone can run a user node. It will stay in sync with the other nodes in the Nile Testnet, it just won't have a say on whether transactions are valid.
 Marketplaces and publishers should run user nodes.
 See the pages for [marketplaces](/setup/marketplace/) and [publishers](/setup/publisher/).

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -5,7 +5,7 @@ description: A tutorial about how to get Ether and Ocean Tokens for testnets.
 
 If you want to interact with a testnet, then you'll eventually need Ether or Ocean Tokens _for that testnet_. (Every Ethereum-based network has its own Ether and its own Ocean Tokens, and you can't use those in other networks, or at least it wasn't possible when we wrote this.)
 
-At the time of writing, there were two public testnets you could use to test an Ocean Protocol application: the Kovan Testnet and the Ocean Testnet. For more information about those, see the page about [testnets](/concepts/testnets/). You could also run a local testnet (i.e. on your local machine).
+At the time of writing, there were some public testnets you could use to test an Ocean Protocol application. For more information about those, see the page about [testnets](/concepts/testnets/). You could also run a local testnet (i.e. on your local machine).
 
 ## Get a Compatible Wallet
 
@@ -24,9 +24,9 @@ You can get Kovan Ether (KEth), for the Kovan Testnet, from a Kovan faucet: see 
 0xa0A9d7f78bF293514e7cA2789A0Af689eEC99282
 ```
 
-### Get Ether for the Ocean Testnet
+### Get Ether for the Nile Testnet
 
-At the time of writing, there was no easy way to get Ether for the Ocean Testnet.
+At the time of writing, there was no easy way to get Ether for the Nile Testnet.
 
 ### Get Ether for a Local Ganache-Based Testnet
 


### PR DESCRIPTION
I noticed that we're renaming the Trilobite/Ocean POA Testnet as the Nile Testnet, e.g. in https://github.com/oceanprotocol/keeper-contracts/pull/201

This pull request makes the same change in docs.oceanprotocol.com.