### PR TITLE
tweak deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,26 +13,21 @@ set -e;
 
 function s3sync {
   aws s3 sync ./public s3://"$1" \
-    --exclude "*" \
-    --include "*.js" \
-    --include "*.css" \
-    --include "static/*" \
-    --include "icons/*" \
-    --exclude "sw.js" \
-    --exclude "workbox*/*" \
     --cache-control public,max-age=31536000,immutable \
     --delete \
-    --acl public-read \
-    --quiet
+    --acl public-read
 
   aws s3 sync ./public s3://"$1" \
     --exclude "*" \
     --include "*.html" \
     --include "sw.js" \
+    --include "chunk-map.json" \
+    --include "sitemap.xml" \
+    --include ".iconstats.json" \
+    --include "robots.txt" \
     --cache-control public,max-age=0,must-revalidate \
     --delete \
-    --acl public-read \
-    --quiet
+    --acl public-read
 }
 
 ##


### PR DESCRIPTION
* cache everything by default
* so all files get the `public-read` ACL by default, which fixes current console errors on live
* modify cache headers for selected files afterwards
* no cache for more selected files which should make service worker updates more reliable
* be more verbose during deployment