### PR TITLE
Add link & explanation of Jupyter notebook tuts

### DIFF
--- a/content/concepts/tools.md
+++ b/content/concepts/tools.md
@@ -3,20 +3,18 @@ title: Tools & Examples
 description: Tools and examples for developing with Ocean Protocol.
 ---
 
-The Setup & Tutorials sections have some examples to get you started.
-
-- [Setup: Quick Start](/setup/quickstart/)
-- [Tutorials: Introduction](/tutorials/introduction/)
-
 ## Tools
 
 Coming soon!
 
 ## Examples
 
+The [Tutorials](/tutorials/introduction/) include many examples.
+
 Examples of using the [🦑 squid-py](https://github.com/oceanprotocol/squid-js) Python library:
 
 <repo name="mantaray"></repo>
+<repo name="tuna"></repo>
 
 Examples of using the [🦑 squid-js](https://github.com/oceanprotocol/squid-js) JavaScript library:
 

--- a/content/tutorials/introduction.md
+++ b/content/tutorials/introduction.md
@@ -3,14 +3,9 @@ title: Overview of the Tutorials
 description: What you can expect to find in these Ocean Protocol tutorials.
 ---
 
-These tutorials give examples of how to use squid-js (JavaScript) and squid-py (Python) to:
+The idea of these tutorials is to show you how to use squid-js (JavaScript) and squid-py (Python) to:
 
 - publish a data set
-- publish a compute service
 - get and use a data set
+- publish a compute service
 - get and use a compute service
-
-The Python tutorials use [Jupyter notebooks](http://jupyter.org/).
-For now, check out [the Mantaray repository](https://github.com/oceanprotocol/mantaray). In the future, we hope to have live online Jupyter notebooks.
-
-<repo name="mantaray"></repo>

--- a/content/tutorials/jupyter-notebooks.md
+++ b/content/tutorials/jupyter-notebooks.md
@@ -1,0 +1,17 @@
+---
+title: Jupyter Notebooks
+description: Try some online interactive squid-py tutorials.
+---
+
+You can go through interactive squid-py tutorials at [datascience.oceanprotocol.com](https://datascience.oceanprotocol.com/).
+They're [Jupyter Notebooks](http://jupyter.org/) running on your own [JupyterLab](https://github.com/jupyterlab/jupyterlab) instance.
+It's quite easy to figure out, but if you get stuck, here are some initial steps:
+
+- Visit [datascience.oceanprotocol.com](https://datascience.oceanprotocol.com/).
+- Click the **JupyterLab Instance** button.
+- Login with your GitHub account.
+- Once you're in the JupyterLab console, double-click on **mantaray_jupyter**.
+- Double-click on **introdution.txt** and read it.
+- Double-click on one of the **.ipynb** files. They're labelled to appear in a logical order.
+- When asked to select a kernel, select Python 3.
+- To make stuff happen (e.g. to run code cells), use the menus at the top of the JupyterLab console, or at the top of your current Jupyter notebook.

--- a/data/sidebars/tutorials.yml
+++ b/data/sidebars/tutorials.yml
@@ -7,7 +7,7 @@
     - title: Set Up Azure Storage
       link: /tutorials/azure-for-brizo/
 
-- group: React App Tutorial
+- group: React App Tutorial (squid-js)
   items:
     - title: Setup
       link: /tutorials/react-setup/
@@ -15,3 +15,8 @@
       link: /tutorials/react-publish-data-set/
     - title: Get & Use a Data Set
       link: /tutorials/react-get-use-data-set/
+
+- group: squid-py Tutorials
+  items:
+    - title: Jupyter Notebooks
+      link: /tutorials/jupyter-notebooks/


### PR DESCRIPTION
- Added a new subsection to the **Tutorials** section: **squid-py Tutorials**, with one page in it so far: **Jupyter Notebooks**.
- That new **Jupyter Notebooks** page gives a quick introduction to what the Jupyter notebooks are about, links to them at https://datascience.oceanprotocol.com/ and gives some tips on how to get started with them.
- Made the **Introduction** page for the **Tutorials** section shorter and more accurate.
- Simplified the **Tools & Examples** page
- Added tuna to the list of squid-py examples