### PR TITLE
Link to the squid-py API Reference Docs

### DIFF
--- a/content/references/introduction.md
+++ b/content/references/introduction.md
@@ -16,4 +16,7 @@ References of all the functions and methods used in our libraries are not yet in
 
 <repo name="squid-js"></repo>
 <repo name="squid-py"></repo>
+
+ReadTheDocs hosts the [squid-py API Reference Docs](https://squid-py.readthedocs.io/en/latest/).
+
 <repo name="squid-java"></repo>

--- a/content/references/squid-py.md
+++ b/content/references/squid-py.md
@@ -1,0 +1,6 @@
+---
+title: API Reference
+description: 
+---
+
+ReadTheDocs hosts the [squid-py API Reference Docs](https://squid-py.readthedocs.io/en/latest/).

--- a/data/sidebars/references.yml
+++ b/data/sidebars/references.yml
@@ -5,15 +5,20 @@
 
 # - group: squid-js
 #   items:
-#     - title: API reference
-#       link: /api/squid-js/
+#     - title: API Reference
+#       link: /references/squid-js/
+
+- group: squid-py
+  items:
+    - title: API Reference
+      link: /references/squid-py/
 
 - group: aquarius
   items:
-    - title: API reference
+    - title: API Reference
       link: /references/aquarius/
 
 - group: brizo
   items:
-    - title: API reference
+    - title: API Reference
       link: /references/brizo/


### PR DESCRIPTION
The squid-py API Reference Docs are probably good enough that we can link to them now.