### PR TITLE
Remove homepage quickstart & fix Quickstart page

### DIFF
--- a/content/setup/quickstart.md
+++ b/content/setup/quickstart.md
@@ -3,6 +3,12 @@ title: Quickstart
 description: Do a quick test drive.
 ---
 
+## Option 1
+
+You can [try some free, online Jupyter notebooks](/tutorials/jupyter-notebooks/) that connect to a live Ocean test network.
+
+## Option 2
+
 You can run and try every [Ocean software component](/concepts/components/) in your local machine, all at once, using Docker Compose.
 
 First, you must [set up some storage on Azure](/tutorials/azure-for-brizo/). (Yes, we know that's not quick. Some day there will be a local storage option and then this really will be quick.)

--- a/content/setup/quickstart.md
+++ b/content/setup/quickstart.md
@@ -3,7 +3,11 @@ title: Quickstart
 description: Do a quick test drive.
 ---
 
-You can run and try every [Ocean software component](/concepts/components/) in your local machine, all at once, using Docker Compose:
+You can run and try every [Ocean software component](/concepts/components/) in your local machine, all at once, using Docker Compose.
+
+First, you must [set up some storage on Azure](/tutorials/azure-for-brizo/). (Yes, we know that's not quick. Some day there will be a local storage option and then this really will be quick.)
+
+Then:
 
 ```bash
 git clone https://github.com/oceanprotocol/barge.git
@@ -19,8 +23,6 @@ Seeing the dolphin means it's working:
 Once everything is up and running, you can interact with the components. For example, to interact with Pleuston, go to:
 
 [http://localhost:3000/](http://localhost:3000/)
-
-Note that everything is running on your local machine, including a local Ethereum node, and it's not connected to any external Ethereum network.
 
 For the details of what components are running, see the [Ocean Protocol barge repository](https://github.com/oceanprotocol/barge).
 

--- a/src/components/Repositories/QuickRun.jsx
+++ b/src/components/Repositories/QuickRun.jsx
@@ -1,3 +1,4 @@
+/*
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
@@ -38,3 +39,4 @@ QuickRun.propTypes = {
 }
 
 export default QuickRun
+*/

--- a/src/components/Repositories/index.jsx
+++ b/src/components/Repositories/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link, StaticQuery, graphql } from 'gatsby'
 import RepositoryList from './RepositoryList'
-import QuickRun from './QuickRun'
+// import QuickRun from './QuickRun'
 import styles from './index.module.scss'
 
 const query = graphql`

--- a/src/components/Repositories/index.jsx
+++ b/src/components/Repositories/index.jsx
@@ -32,7 +32,7 @@ const Repositories = () => (
 
             return (
                 <div className={styles.repositories}>
-                    <QuickRun name="barge" />
+                    {/* <QuickRun name="barge" /> */}
 
                     <header>
                         <h1 className={styles.repositoriesTitle}>


### PR DESCRIPTION
Today, if you just do:
```text
git clone https://github.com/oceanprotocol/barge.git
cd barge/

./start_ocean.sh --latest
```
as suggested on the docs.oceanprotocol.com home page (and in the Quickstart page), it won't work because Brizo needs to connect to some storage and none is set up. They must set up Azure storage first.

Before Christmas, my impression was that a local storage option was going to be added right away, and it would be the Barge default, so the above quickstart would work. Therefore I felt no need to make any changes.

Apparently that didn't happen (yet). This pull request makes changes to make the quickstart user experience better:

1. On the Quickstart page (in the Setup Guides), tell them they must set up some Azure storage first, and link to the tutorial about how to do that. Also, it seems the default is to use the Nile network, which is external, so I removed the sentence about not connecting to an external network.
2. Remove the above quickstart snippet from the docs home page. Setting up Azure storage _isn't quick_ (yet). (I just commented-out the HTML so it can be brought back quickly in the future.)
