### PR TITLE
In Terminology page, add link to Wallets page

### DIFF
--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -39,4 +39,5 @@ We published an [Ocean Protocol blog post that explains SEAs in more detail](htt
 
 ## More Terminology
 
-See the page about Ocean's [Software Components](/concepts/components/).
+- See [the page about Ocean's Software Components](/concepts/components/).
+- See [the page about wallets (and other Ethereum terminology)](/tutorials/wallets/).


### PR DESCRIPTION
This was suggested by an external party, because the Wallets page also defines a lot of terminology (although it isn't Ocean-specific).