### PR TITLE
fix aggressive prims.js syntax styles for inline code

### DIFF
--- a/src/components/DocContent.module.scss
+++ b/src/components/DocContent.module.scss
@@ -27,6 +27,36 @@
         word-wrap: normal;
         word-break: normal;
     }
+
+    :not(pre) > code {
+        background: darken($brand-white, 5%);
+        color: $brand-grey-dark;
+        display: inline-block;
+        padding-left: .3rem;
+        padding-right: .3rem;
+    }
+
+    pre {
+        display: block;
+        margin-bottom: $spacer;
+        padding: 0;
+        background: $brand-black;
+
+        // make 'em scrollable
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+
+        code {
+            padding: $spacer;
+            white-space: pre;
+            display: block;
+            color: $brand-grey-lighter;
+            overflow-wrap: normal;
+            word-wrap: normal;
+            word-break: normal;
+            overflow: auto;
+        }
+    }
 }
 
 .empty {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -282,35 +282,35 @@ samp {
     }
 }
 
-:not(pre) > code {
-    background: darken($brand-white, 5%);
-    color: $brand-grey-dark;
-    display: inline-block;
-    padding-left: .3rem;
-    padding-right: .3rem;
-}
+// :not(pre) > code {
+//     background: darken($brand-white, 5%);
+//     color: $brand-grey-dark;
+//     display: inline-block;
+//     padding-left: .3rem;
+//     padding-right: .3rem;
+// }
 
-pre {
-    display: block;
-    margin-bottom: $spacer !important;
-    padding: 0 !important;
-    background: $brand-black !important;
+// pre {
+//     display: block;
+//     margin-bottom: $spacer;
+//     padding: 0;
+//     background: $brand-black;
 
-    // make 'em scrollable
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
+//     // make 'em scrollable
+//     overflow: auto;
+//     -webkit-overflow-scrolling: touch;
 
-    code {
-        padding: $spacer;
-        white-space: pre;
-        display: block;
-        color: $brand-grey-lighter !important;
-        overflow-wrap: normal;
-        word-wrap: normal;
-        word-break: normal;
-        overflow: auto;
-    }
-}
+//     code {
+//         padding: $spacer;
+//         white-space: pre;
+//         display: block;
+//         color: $brand-grey-lighter;
+//         overflow-wrap: normal;
+//         word-wrap: normal;
+//         word-break: normal;
+//         overflow: auto;
+//     }
+// }
 
 // Selection
 /////////////////////////////////////


### PR DESCRIPTION
The prims.js styles are inlined at top of page so they clash with our own styles for inline code, which is different than what the prism.js theme provides. Solve this by increasing the specificity of our own `code` styles.