### PR TITLE
Add "✋ Ask a question on Gitter" to the footer

### DIFF
--- a/src/components/DocFooter.jsx
+++ b/src/components/DocFooter.jsx
@@ -24,6 +24,10 @@ const DocFooter = ({ post, url, externalName }) => {
 
     return (
         <footer className={styles.footer}>
+            <a href="https://gitter.im/oceanprotocol/Lobby" className={post && !post.html ? styles.active : null}>
+                ✋ Ask a question on Gitter
+            </a>
+            <br>
             <a href={url} className={post && !post.html ? styles.active : null}>
                 <Pencil /> Edit this page on GitHub
                 {externalName && (


### PR DESCRIPTION
- If people have questions about the docs, this makes it really easy for them to figure out where to ask. (There's already a link to Gitter in the very bottom footer, but I'm not sure everyone knows what Gitter is, or what you can do there.)
- I'm not sure what the `className` part is doing so that might require modification. I just copied it from the markup for "Edit this page on GitHub".
- The "raised hand" character is a standard Unicode character that I copied and pasted from elsewhere. Maybe it would be better to use an HTML form such as `&#9995;`? See https://www.fileformat.info/info/unicode/char/270b/index.htm 
