### PR TITLE
Point Quickstart option 2 to Barge repo for now

### DIFF
--- a/content/concepts/wallets.md
+++ b/content/concepts/wallets.md
@@ -40,7 +40,7 @@ We encourage you to search around and read about wallets to understand the optio
 
 ## Wallets which Might Work with Ocean Tokens
 
-[ERC-20 tokens](https://en.wikipedia.org/wiki/ERC-20) are the most common kind of tokens found in Ethereum-based networks. **Ocean Tokens are ERC-20 tokens**, so any wallet that supports arbitrary ERC-20 tokens should work to hold Ocean Tokens. 
+[ERC-20 tokens](https://en.wikipedia.org/wiki/ERC-20) are the most common kind of tokens found in Ethereum-based networks. **Ocean Tokens are ERC-20 tokens**, so any wallet that supports arbitrary ERC-20 tokens should work to hold Ocean Tokens.
 
 For example, you could use [MetaMask](https://metamask.io/), either as a stand-alone wallet, or with to a hardware wallet. We have a [tutorial about how to set up MetaMask for Chrome](/tutorials/metamask-setup).
 

--- a/content/setup/quickstart.md
+++ b/content/setup/quickstart.md
@@ -9,8 +9,24 @@ You can [try some free, online Jupyter notebooks](/tutorials/jupyter-notebooks/)
 
 ## Option 2
 
+**WARNING: This option is more for developers who don't mind some things not working together as expected (if at all). Eventually there will be a default-working version, but that doesn't exist yet.**
+
 You can run and try every [Ocean software component](/concepts/components/) in your local machine, all at once, using Docker Compose. Ocean Protocol software developers do this often, to test their code against all the other Ocean components.
 
-The Docker Compose files–and instructions to use them–are in [the Barge repository on GitHub](https://github.com/oceanprotocol/barge).
+```bash
+git clone https://github.com/oceanprotocol/barge.git
+cd barge/
+./start_ocean.sh --latest
+```
+
+Seeing the dolphin means it's working:
+
+![start_ocean.sh](images/dolphin.png)
+
+Once everything is up and running, you can interact with the components. For example, to interact with Pleuston, go to:
+
+[http://localhost:3000/](http://localhost:3000/)
+
+For the details of what components are running, see the [Ocean Protocol barge repository](https://github.com/oceanprotocol/barge).
 
 <repo name="barge"></repo>

--- a/content/setup/quickstart.md
+++ b/content/setup/quickstart.md
@@ -9,27 +9,8 @@ You can [try some free, online Jupyter notebooks](/tutorials/jupyter-notebooks/)
 
 ## Option 2
 
-You can run and try every [Ocean software component](/concepts/components/) in your local machine, all at once, using Docker Compose.
+You can run and try every [Ocean software component](/concepts/components/) in your local machine, all at once, using Docker Compose. Ocean Protocol software developers do this often, to test their code against all the other Ocean components.
 
-First, you must [set up some storage on Azure](/tutorials/azure-for-brizo/). (Yes, we know that's not quick. We're working on making a quicker option.)
-
-Then:
-
-```bash
-git clone https://github.com/oceanprotocol/barge.git
-cd barge/
-
-./start_ocean.sh --latest
-```
-
-Seeing the dolphin means it's working:
-
-![start_ocean.sh](images/dolphin.png)
-
-Once everything is up and running, you can interact with the components. For example, to interact with Pleuston, go to:
-
-[http://localhost:3000/](http://localhost:3000/)
-
-For the details of what components are running, see the [Ocean Protocol barge repository](https://github.com/oceanprotocol/barge).
+The Docker Compose files–and instructions to use them–are in [the Barge repository on GitHub](https://github.com/oceanprotocol/barge).
 
 <repo name="barge"></repo>


### PR DESCRIPTION
Quickstart option 2 isn't fully working right now because Barge isn't working fully right now, but as soon as it is, the Barge `README.md` file will be the first to be updated. Later, we can update the Quickstart page in the docs (which has a boiled-down version of the Barge `README.md` file).

For now, option 2 mainly just points to the Barge repo (i.e. the Barge `README.md` file).

Related: https://github.com/oceanprotocol/barge/pull/119
