### PR TITLE
Updated the Tools & Examples page

### DIFF
--- a/content/concepts/tools.md
+++ b/content/concepts/tools.md
@@ -5,24 +5,29 @@ description: Tools and examples for developing with Ocean Protocol.
 
 ## Tools
 
-[Plecos](https://github.com/oceanprotocol/plecos) is a Python tool to check metadata (a JSON file) to see if it conforms to the [OEP8 schema](https://github.com/oceanprotocol/OEPs/tree/master/8). Plecos wraps the [jsonschema](https://github.com/Julian/jsonschema) validator.
+### Plecos
 
-Users can use Plecos to check their metadata before sending it to an Aquarius instance. Plecos is manually updated with a schema file according to [OEP8](https://github.com/oceanprotocol/OEPs/tree/master/8). Find the tool in [PyPI](https://pypi.org/project/plecos/).
-
-Plecos can be used in a microservice to facilitate data onboarding, as described in the [plecos_service](https://github.com/oceanprotocol/plecos_service) repository.
+Plecos is a Python tool to check metadata (a JSON file) to see if it conforms to the [OEP8 schema](https://github.com/oceanprotocol/OEPs/tree/master/8). Plecos wraps the [jsonschema](https://github.com/Julian/jsonschema) validator. Users can use Plecos to check their metadata before sending it to an Aquarius instance. Aquarius can also use it to check metadata. Plecos can be found in [the Plecos repository on GitHub](https://github.com/oceanprotocol/plecos) and as [a Python package in PyPI](https://pypi.org/project/plecos/).
 
 <repo name="Plecos"></repo>
 
+Plecos can be used in a microservice to facilitate data onboarding, as described in the [plecos_service repository](https://github.com/oceanprotocol/plecos_service).
+
 ## Examples
 
-The [Tutorials](/tutorials/introduction/) include many examples.
+### squid-py Examples
 
-Examples of using the [🦑 squid-py](https://github.com/oceanprotocol/squid-js) Python library can be found in the [squid_py/examples/ directory of the squid-py repository](https://github.com/oceanprotocol/squid-py/tree/develop/squid_py/examples). More examples are in the repositories:
+- [The squid-py tutorials in Jupyter notebooks](/tutorials/jupyter-notebooks/)
+- [The squid_py/examples/ directory of the squid-py repository](https://github.com/oceanprotocol/squid-py/tree/develop/squid_py/examples)
+- [The squid-py tests](https://github.com/oceanprotocol/squid-py/tree/develop/tests)
 
-<repo name="mantaray"></repo>
-<repo name="tuna"></repo>
+### squid-js Examples
 
-Examples of using the [🦑 squid-js](https://github.com/oceanprotocol/squid-js) JavaScript library can be found in the [src/examples/ directory of the squid-js repository](https://github.com/oceanprotocol/squid-js/tree/develop/src/examples). More examples are in the repositories:
+- [The React App Tutorial](/tutorials/react-setup/)
+- [The src/examples/ directory of the squid-js repository](https://github.com/oceanprotocol/squid-js/tree/develop/src/examples)
+- [The squid-js tests](https://github.com/oceanprotocol/squid-js/tree/develop/test)
 
-<repo name="pleuston"></repo>
-<repo name="tuna"></repo>
+### squid-java Examples
+
+- [The squid-java README.md file](https://github.com/oceanprotocol/squid-java/blob/develop/README.md)
+- [The squid-java tests](https://github.com/oceanprotocol/squid-java/tree/develop/src/test)

--- a/content/tutorials/introduction.md
+++ b/content/tutorials/introduction.md
@@ -3,9 +3,4 @@ title: Overview of the Tutorials
 description: What you can expect to find in these Ocean Protocol tutorials.
 ---
 
-The idea of these tutorials is to show you how to use squid-js (JavaScript), squid-py (Python) and squid-java to:
-
-- publish a data set
-- get and use a data set
-- publish a compute service
-- get and use a compute service
+The idea of these tutorials is to show you how to use squid-js (JavaScript), squid-py (Python) and squid-java to publish a data set, to get & use a data set, and to do other things.

--- a/content/tutorials/jupyter-notebooks.md
+++ b/content/tutorials/jupyter-notebooks.md
@@ -16,4 +16,7 @@ It's quite easy to figure out, but if you get stuck, here are some initial steps
 - When asked to select a kernel, select Python 3.
 - To make stuff happen (e.g. to run code cells), use the menus at the top of the JupyterLab console, or at the top of your current Jupyter notebook.
 
-For more info, see the blog post titled, "[Project Manta Ray — Data Science powered by Ocean Protocol](https://blog.oceanprotocol.com/project-manta-ray-data-science-powered-by-ocean-protocol-535c54089b0f)."
+For more info, see the blog posts:
+
+- "[Project Manta Ray — Data Science powered by Ocean Protocol](https://blog.oceanprotocol.com/project-manta-ray-data-science-powered-by-ocean-protocol-535c54089b0f)"
+- "[The Data Science Workflow — Powered by Ocean Protocol](https://blog.oceanprotocol.com/dive-into-ocean-protocol-ai-ecosystem-60f64eddf74d)"


### PR DESCRIPTION
Revised the Examples section of the **Tools & Examples** page to have three parts, one for each of squid-py, squid-js and squid-java. Removed any mention of Tuna because it's outdated. (I confirmed that with Dimi.) Added links to the tests (for all three) because those are good examples (and must be up-to-date). 

Also:
- Removed mention of compute services in the Tutorials introduction page.
- Added link to the new data science blog post.