### PR TITLE
Simplify Wallet Basics + Metamask Tutorial pages

### DIFF
--- a/content/concepts/wallets.md
+++ b/content/concepts/wallets.md
@@ -9,21 +9,26 @@ If you want to use the Ocean Network, then you need Ocean Tokens ([ERC-20 tokens
 
 ## What Crypto Wallets Can Be Used with Ocean?
 
-1. [MetaMask](https://metamask.io/) with on-disk storage of private keys (the default). See the [MetaMask setup tutorial](/tutorials/metamask-setup/).
-1. [MetaMask](https://metamask.io/) with a [TREZOR](https://trezor.io/) hardware wallet to store private keys.
-1. [MetaMask](https://metamask.io/) with a [Ledger](https://www.ledger.com/) hardware wallet to store private keys.
-1. Maybe others?
+The following combinations will almost certainly work:
 
-**Not MyEtherWallet, except to get Ethereum account addresses from a hardware wallet.**
+Wallet User Interface Software | Access Wallet with           | Wallet (Stores Private Keys)
+-------------------------------|------------------------------|-----------------------------
+[MetaMask][1]                  | [MetaMask][1]                | [MetaMask][1]
+[MetaMask][1]                  | [MetaMask][1]                | [TREZOR][2] hardware wallet
+[MyEtherWallet][4]             | [MetaMask][1]                | [MetaMask][1]
+[MyEtherWallet][4]             | [MetaMask][1]                | [TREZOR][2] hardware wallet
+[MyCrypto][5]                  | [MetaMask][1]                | [MetaMask][1]
+[MyCrypto][5]                  | [MetaMask][1]                | [TREZOR][2] hardware wallet
+[MyCrypto][5]                  | [TREZOR][2] hardware wallet  | [TREZOR][2] hardware wallet
 
-Why only those ones?
+Note: Other combinations will _probably_ also work. For example, a [Ledger][3] hardware wallet can probably be used in place of a TREZOR hardware wallet.
 
-You need a crypto wallet that can:
+See the [MetaMask setup tutorial](/tutorials/metamask-setup/).
+
+Why only those combinations? You need a combination that can:
 
 1. connect to both the Main Ethereum Network or the Main Ocean Network (or a custom network), and
 1. manage Ether and Ocean Tokens (or custom tokens).
-
-At the time of writing, the Main Ocean Network was not in the list of networks that MyEtherWallet could connect to, and you couldn't connect to a custom network (custom RPC). MetaMask _did_ allow connecting to a custom network, such as the Main Ocean Network.
 
 ## Terminology
 
@@ -44,14 +49,20 @@ Notes:
 
 ## Types of Wallets
 
-It's easy to get confused or overwhelmed by all the types of wallets. However, there are really only a few questions you need to ask about a given wallet:
+It's easy to get confused or overwhelmed by all the types of wallets and all the options for accessing them. However, there are really only a few questions you need to ask about a given wallet + software combination:
 
 1. Where are my private keys stored? How secure is that?
-1. Can the wallet software connect to the networks I care about (such as the Main Ocean Network)?
-1. Can the wallet software manage the cryptocurrencies I care about (such as Ocean Tokens)?
+1. Can the combination connect to the networks I care about (such as the Main Ocean Network)?
+1. Can the combination be used to manage the cryptocurrencies I care about (such as Ocean Tokens)?
 
 Hardware wallets store private keys inside a "secure enclave" (on a special device) so they can't be read out easily. All you can do is send a transaction to the hardware wallet to get the transaction signed by the private key. It then returns the signed transaction. The private key never leaves the hardware wallet.
 Other wallets store private keys on a hard drive, in memory, on a remote server, or on a piece of paper.
 Each option gives you a tradeoff between security and ease of use / convenience. It's easier to steal or delete a private key if it's stored on a computer, especially a computer that's connected to the internet.
 
 We encourage you to search around and read about wallets to understand the options. This page isn't a deep dive; it's just a primer.
+
+[1]: https://metamask.io/
+[2]: https://trezor.io/
+[3]: https://www.ledger.com/
+[4]: https://www.myetherwallet.com/
+[5]: https://www.mycrypto.com/

--- a/content/concepts/wallets.md
+++ b/content/concepts/wallets.md
@@ -17,6 +17,7 @@ Wallet User Interface Software | Access Wallet with           | Wallet (Stores P
 [MetaMask][1]                  | [MetaMask][1]                | [TREZOR][2] hardware wallet
 [MyEtherWallet][4]             | [MetaMask][1]                | [MetaMask][1]
 [MyEtherWallet][4]             | [MetaMask][1]                | [TREZOR][2] hardware wallet
+[MyEtherWallet][4]             | [TREZOR][2] hardware wallet  | [TREZOR][2] hardware wallet
 [MyCrypto][5]                  | [MetaMask][1]                | [MetaMask][1]
 [MyCrypto][5]                  | [MetaMask][1]                | [TREZOR][2] hardware wallet
 [MyCrypto][5]                  | [TREZOR][2] hardware wallet  | [TREZOR][2] hardware wallet

--- a/content/concepts/wallets.md
+++ b/content/concepts/wallets.md
@@ -5,7 +5,27 @@ description: Ocean users need a wallet to manage their Ocean Tokens and Ether. T
 
 ## Introduction
 
-If you want to use the Ocean Network, then you need Ocean Tokens (typical ERC-20 tokens) and Ether, and to get Ocean Tokens and Ether, you need a _cryptocurrency wallet_ or _crypto wallet_ to manage them.
+If you want to use the Ocean Network, then you need Ocean Tokens ([ERC-20 tokens](https://en.wikipedia.org/wiki/ERC-20)) and Ether. To get and manage Ocean Tokens and Ether, you need a _cryptocurrency wallet_ or _crypto wallet_.
+
+## What Crypto Wallets Can Be Used with Ocean?
+
+1. [MetaMask](https://metamask.io/) with on-disk storage of private keys (the default). See the [MetaMask setup tutorial](/tutorials/metamask-setup/).
+1. [MetaMask](https://metamask.io/) with a [TREZOR](https://trezor.io/) hardware wallet to store private keys.
+1. [MetaMask](https://metamask.io/) with a [Ledger](https://www.ledger.com/) hardware wallet to store private keys.
+1. Maybe others?
+
+**Not MyEtherWallet, except to get Ethereum account addresses from a hardware wallet.**
+
+Why only those ones?
+
+You need a crypto wallet that can:
+
+1. connect to both the Main Ethereum Network or the Main Ocean Network (or a custom network), and
+1. manage Ether and Ocean Tokens (or custom tokens).
+
+At the time of writing, the Main Ocean Network was not in the list of networks that MyEtherWallet could connect to, and you couldn't connect to a custom network (custom RPC). MetaMask _did_ allow connecting to a custom network, such as the Main Ocean Network.
+
+## Terminology
 
 When you set up a new (crypto) wallet, it might generate a **seed phrase** for you. Store that seed phrase somewhere secure and non-digital (e.g. on paper in a safe). It's extremely secret and sensitive. Anyone with your wallet's seed phrase could spend all the Ether and Ocean Tokens in all the accounts in your wallet.
 
@@ -13,7 +33,7 @@ Once your wallet is set up, it will have one or more **accounts**.
 
 Each account has several **balances**, e.g. an Ether balance, an Ocean Token balance, and maybe other balances. All balances start at zero.
 
-An account's Ether balance might be 7.1 ETH in the Ethereum mainnet, 2.39 ETH in the Kovan testnet, and 0.1 ETH in the Nile testnet. You can't move ETH from one network to another (unless there is a special exchange or bridge set up). The same is true of Ocean Token balances.
+An account's Ether balance might be 7.1 ETH in the Ethereum mainnet, 2.39 ETH in the Kovan testnet, and 0.1 ETH in the Nile testnet. You can't move ETH from one network to another (unless there is a special exchange or bridge set up). The same is true of Ocean Token balances, with one exception: there will be a token bridge allowing you to move Ocean Tokens back and forth between the Ocean mainnet and the Ethereum mainnet (so that the sum of the two Ocean Token balances stays constant).
 
 Each account has one **private key**, one **public key** and one **address**. The public key and address can be calculated from the private key. You must keep the private key secret because it's what's needed to spend/transfer Ether and Ocean Tokens. You can share the address with others. In fact, if you want someone to send some Ether or Ocean Tokens to an account, you give them the account's address.
 
@@ -24,32 +44,14 @@ Notes:
 
 ## Types of Wallets
 
-It's easy to get confused or overwhelmed by all the types of wallets. However, there is really only one question you need to ask about a given wallet:
+It's easy to get confused or overwhelmed by all the types of wallets. However, there are really only a few questions you need to ask about a given wallet:
 
-_Where are my private keys stored?_
+1. Where are my private keys stored? How secure is that?
+1. Can the wallet software connect to the networks I care about (such as the Main Ocean Network)?
+1. Can the wallet software manage the cryptocurrencies I care about (such as Ocean Tokens)?
 
 Hardware wallets store private keys inside a "secure enclave" (on a special device) so they can't be read out easily. All you can do is send a transaction to the hardware wallet to get the transaction signed by the private key. It then returns the signed transaction. The private key never leaves the hardware wallet.
-
-Other wallets store private keys on a hard drive, or in memory, or on a remote server.
-
-A "paper wallet" is just a piece of paper with one or more private keys written on it.
-
+Other wallets store private keys on a hard drive, in memory, on a remote server, or on a piece of paper.
 Each option gives you a tradeoff between security and ease of use / convenience. It's easier to steal or delete a private key if it's stored on a computer, especially a computer that's connected to the internet.
 
 We encourage you to search around and read about wallets to understand the options. This page isn't a deep dive; it's just a primer.
-
-## Wallets which Might Work with Ocean Tokens
-
-[ERC-20 tokens](https://en.wikipedia.org/wiki/ERC-20) are the most common kind of tokens found in Ethereum-based networks. **Ocean Tokens are ERC-20 tokens**, so any wallet that supports arbitrary ERC-20 tokens should work to hold Ocean Tokens. 
-
-For example, you could use [MetaMask](https://metamask.io/), either as a stand-alone wallet, or with to a hardware wallet. We have a [tutorial about how to set up MetaMask for Chrome](/tutorials/metamask-setup).
-
-Other wallets which _might_ work with Ocean Tokens are:
-
-- [Gnosis Safe](https://safe.gnosis.io)
-- [Trust Wallet](https://trustwallet.com)
-- [Tokenary](https://tokenary.io)
-- [Ledger](https://www.ledger.com/) hardware wallets (along with Ledger software)
-- [TREZOR](https://trezor.io/) hardware wallets (along with other software such as MyEtherWallet)
-
-**We don't recommend or endorse any particular wallets at this time.**

--- a/content/tutorials/metamask-setup.md
+++ b/content/tutorials/metamask-setup.md
@@ -5,7 +5,11 @@ description: Tutorial about how to set up MetaMask for Chrome.
 
 ## What is MetaMask?
 
-[MetaMask](https://metamask.io/) is a browser extension that can be used as a [crypto wallet](/concepts/wallets) for Ether and ERC-20 tokens (such as Ocean tokens).
+[MetaMask](https://metamask.io/) is a browser extension that can:
+
+- be used as a [wallet](/concepts/wallets) for Ether and ERC-20 tokens (such as Ocean tokens),
+- connect to TREZOR and Ledger hardware wallets,
+- be used to send Ether and ERC-20 tokens (i.e. to create, sign, and send Ethereum transactions).
 
 ## How to Set Up MetaMask for Chrome
 

--- a/content/tutorials/metamask-setup.md
+++ b/content/tutorials/metamask-setup.md
@@ -5,13 +5,11 @@ description: Tutorial about how to set up MetaMask for Chrome.
 
 ## What is MetaMask?
 
-[MetaMask](https://metamask.io/) is a browser extension that allows web applications to interact with the Ethereum blockchain. Today, web browsers like Chrome and Firefox display information by fetching it from a server. Our current web browsers (Web 2.0 as it’s called) are not built to interface with distributed systems. MetaMask allows modern web browsers to interact with the Ethereum blockchain.
-
-MetaMask serves a dual purpose as a [wallet](/concepts/wallets) (for Ether and ERC-20 tokens) and as a Web 3.0 browser. For users, it can work as an Ethereum wallet. For developers, it allows you to design and run Ethereum DApps right in your browser without running a full Ethereum node. MetaMask talks to the Ethereum blockchain for you.
+[MetaMask](https://metamask.io/) is a browser extension that can be used as a [crypto wallet](/concepts/wallets) for Ether and ERC-20 tokens (such as Ocean tokens).
 
 ## How to Set Up MetaMask for Chrome
 
-**Note: MetaMask can also be used with a hardware wallet but we don't cover that option below.**
+**Note: MetaMask can also be used with a TREZOR or Ledger hardware wallet but we don't cover that option below; see [the MetaMask documentation](https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet).**
 
 1. Go to the [Chrome Web Store for extensions](https://chrome.google.com/webstore/category/extensions) and search for MetaMask.
 


### PR DESCRIPTION
This pull request makes more simplifications to the pages about wallets: the **Wallet Basics** page and the **Set Up MetaMask** page.

- The **Wallet Basics** page now begins with a short list of the wallet + storage options which I know will work for people who want to manage Ocean Tokens; there's no more waffling by giving a list of popular wallets that might or might not work. We can add more options when we're sure they'll work. Meanwhile I listed the criteria for getting on the list.
- I was testing MyEtherWallet today and it doesn't allow for connecting to a custom network (such as the Main Ocean Network will be at launch) so MyEtherWallet is not going to be an option at first. I added a note about that (and why). (I think MyEtherWallet _used to_ support connecting to custom networks but it seems to be gone in the latest version; I would be happy to be wrong about that though.)
- Simplified the section about the Types of Wallets some more.
- In the tutorial page about how to set up MetaMask for Chrome:
  - Simplified the introduction. It didn't have to be so verbose.
  - Added a link to the MetaMask docs about how to connect MetaMask to a TREZOR or Ledger hardware wallet.
