### PR TITLE
Try to enforce py3 & pip3 in Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ script:
   - npm test
   - 'if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then npm run build; fi'
 
-# Try to ensure Python 3 and pip3 get used for deployment.
-# Note that "alias" commands do not work in .travis.yml
 after_success:
-  - pyenv global 3.6
   - pip3 install --user awscli
   - export PATH=$PATH:$HOME/.local/bin
   - npm run deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,20 @@ dist: xenial
 
 # Deploying uses awscli and it uses Python.
 # Xenial on Travis comes with Python 2 & 3 installed but 2 is default.
-# Ensure pip3 is installed
-# and make python3 and pip3 the defaults:
+# Ensure pip3 is installed and upgraded.
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install python3-pip
-  - alias python=python3
-  - alias pip=pip3
+  - sudo -H pip3 install --upgrade pip
 
 script:
   - npm test
   - 'if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then npm run build; fi'
 
+# Try to ensure Python 3 and pip3 get used for deployment:
 after_success:
-  - pip install --user awscli
+  - alias python=python3
+  - pip3 install --user awscli
   - export PATH=$PATH:$HOME/.local/bin
   - npm run deploy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ script:
   - npm test
   - 'if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then npm run build; fi'
 
-# Try to ensure Python 3 and pip3 get used for deployment:
+# Try to ensure Python 3 and pip3 get used for deployment.
+# Note that "alias" commands do not work in .travis.yml
 after_success:
-  - alias python=python3
+  - pyenv global 3.6
   - pip3 install --user awscli
   - export PATH=$PATH:$HOME/.local/bin
   - npm run deploy

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,9 +11,6 @@ SITEMAP_URL="https%3A%2F%2Fdocs.oceanprotocol.com%2Fsitemap.xml"
 #
 set -e;
 
-echo "Default python (used by awscli):"
-python --version
-
 function s3sync {
   aws s3 sync ./public s3://"$1" \
     --cache-control public,max-age=31536000,immutable \


### PR DESCRIPTION
This is a follow-up to pull request #166.

It attempts to force the Travis deploy script to use Python 3 and pip3.