### PR TITLE
Update & add details to the "Testnets" page

### DIFF
--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -44,12 +44,12 @@ If you want to connect to the Nile Testnet e.g. using MetaMask, then you must en
 
 ### Nile Blockchain Explorers
 
-There is a Nile blockchain explorer at [https://submarine.dev-ocean.com/](https://submarine.dev-ocean.com/). You can use it to check the status of a transaction, the balance of an account, and more. It uses the following symbols for Nile Ether and Ocean Tokens:
+There is a Nile blockchain explorer at [https://submarine.dev-ocean.com/](https://submarine.dev-ocean.com/). You can use it to check the status of a transaction, the balance of an account, and more. It uses the following symbols for Nile Ether and Nile Ocean Tokens:
 
 Cryptocurrency    | Symbol used
 ------------------|------------
 Nile Ether        | POA
-Nile Ocean Tokens | SBT-OCN
+Nile Ocean Tokens | OCEAN or SBT-OCN
 
 ### Keeper Contracts on Nile
 

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -23,10 +23,6 @@ The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-co
 
 Note: Because Ocean Protocol uses ZeppelinOS to manage smart contract upgrades, a keeper contract address might not change over time (because it's just the address _of the proxy contract_) but the actually-used smart contract might change, along with its functionality.
 
-_At the time of writing_, the contract address of the OceanToken contract in Kovan was:
-
-0x963f52e2f4827ef82c56ad2eb81f650f66aeb267
-
 ### Ocean Components Connected to Kovan
 
 There is a [Secret Store](/concepts/components/#secret-store) connected to the Kovan Testnet for use by Ocean Protocol projects (including your projects). It's operated by BigchainDB GmbH. Its URL is:
@@ -58,10 +54,6 @@ Nile Ocean Tokens | SBT-OCN
 ### Keeper Contracts on Nile
 
 See the subsection about the [Keeper Contracts on Kovan](#keeper-contracts-on-kovan). The Nile contract addresses can be found in the same way.
-
-_At the time of writing_, the contract address of the OceanToken contract in Nile was:
-
-0x5b39858a450e8b51b5dcc598aafc4045c499d14f
 
 ### Ocean Components Connected to Nile
 

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -7,7 +7,9 @@ You can test an Ocean Protocol application (such as a marketplace) against the t
 
 ## The Kovan Testnet
 
-The [Kovan Testnet](https://github.com/kovan-testnet/proposal) (or just "Kovan") is a public Ethereum testnet operated by members of the Ethereum community.
+The [Kovan Testnet](https://github.com/kovan-testnet/proposal) (or just "Kovan") is a public Ethereum Testnet operated by members of the Ethereum community.
+
+Most Ethereum wallets and libraries know how to connect to the Kovan Testnet. If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Kovan node, you can connect to that local Kovan node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
 
 ### Kovan Blockchain Explorers
 
@@ -29,18 +31,28 @@ There is a [Secret Store](/concepts/components/#secret-store) connected to the K
 
 [https://secret-store-kovan.dev-ocean.com/](https://secret-store-kovan.dev-ocean.com/)
 
-Aside from the Secret Store, there is no other Ocean Protocol software component (e.g. Aquarius) that is live, connected to the Kovan testnet, and operated by BigchainDB GmbH.
+Aside from the Secret Store, there is no other Ocean Protocol software component (e.g. Aquarius) that is live, connected to the Kovan Testnet, and operated by BigchainDB GmbH.
 
 ## The Nile Testnet
 
 _Formerly called the Ocean POA Testnet._
 
 The Nile Testnet is similar to the Kovan Testnet, except all the nodes are operated by BigchainDB GmbH.
-If you want to connect to the Nile Testnet e.g. using MetaMask, then you must enter an "RPC URL" for the Nile Testnet. It is:
 
-[https://nile.dev-ocean.com/](https://nile.dev-ocean.com/)
+### Nile Testnet Parameters
 
-(You don't need to include the port number.)
+Parameter          | Value
+-------------------|---------------
+RPC URL (required) | [https://nile.dev-ocean.com/](https://nile.dev-ocean.com/)
+ChainID            | 8995 (decimal for MetaMask) or 0x2323 (hexadecimal)
+Symbol             | Whatever you like
+Nickname           | Whatever you like
+
+- In MetaMask, you don't need to include the port number with the RPC URL.
+- If you're using MetaMask, see the [MetaMask docs about how it uses the ChainID](https://metamask.github.io/metamask-docs/Main_Concepts/Sending_Transactions).
+- If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Nile node:
+  - You can connect to that local Nile node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
+  - You can configure that local Nile node by editing the files in the `barge/networks/nile/config/` directory.
 
 ### Nile Blockchain Explorers
 
@@ -57,7 +69,7 @@ See the subsection about the [Keeper Contracts on Kovan](#keeper-contracts-on-ko
 
 ### Ocean Components Connected to Nile
 
-There are several Ocean Protocol software components that are live, connected to the Nile testnet, and operated by BigchainDB GmbH:
+There are several Ocean Protocol software components that are live, connected to the Nile Testnet, and operated by BigchainDB GmbH:
 
 - Secret Store at [https://secret-store.dev-ocean.com](https://secret-store.dev-ocean.com)
 - Aquarius at [https://nginx-aquarius.dev-ocean.com](https://nginx-aquarius.dev-ocean.com)
@@ -65,10 +77,14 @@ There are several Ocean Protocol software components that are live, connected to
 - Jupyter Hub at [https://mantaray.dev-ocean.com](https://mantaray.dev-ocean.com)
 - [Token Bridge Frontend](https://github.com/oceanprotocol/bridge-ui) (for a token bridge between Nile and Kovan) at [https://token-bridge.dev-ocean.com](https://token-bridge.dev-ocean.com)
 
-> Internal note: The private "atlantic" repo documents the internal details of the Nile testnet in `networks/nile/README.md`.
+> Internal note: The private "atlantic" repo documents the internal details of the Nile Testnet in `networks/nile/README.md`.
 
 ## A Spree Testnet
 
-When Ocean Protocol developers run [Barge](https://github.com/oceanprotocol/barge) with the `--local-spree-node` option, a "Spree Testnet" node is deployed on their local machine: a local "testnet" not connected to any public testnet. It's named after the main river flowing through Berlin, Germany, where many Ocean Protocol developers are located.
+When Ocean Protocol developers run [Barge](https://github.com/oceanprotocol/barge) with the `--local-spree-node` option, a "Spree Testnet" is deployed on their local machine: a local testnet not connected to any external public testnet. The RPC URL is [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
 
-Spree testnet details can be found in the [Barge README.md file](https://github.com/oceanprotocol/barge/blob/develop/README.md).
+Spree Testnet details can be found in the [Barge README.md file](https://github.com/oceanprotocol/barge/blob/develop/README.md).
+
+You can configure the Spree nodes by editing the files in the `barge/networks/spree/` directory.
+
+Note: Spree testnets are named after the Spree River, the main river flowing through Berlin, Germany, where many Ocean Protocol developers are located.

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -1,29 +1,82 @@
 ---
 title: Testnets
-description: An overview of public testnets that you can test Ocean Protocol applications against.
+description: An overview of public test networks that you can test Ocean Protocol applications against.
 ---
 
-You can test an Ocean Protocol application (such as a marketplace) against some testnets that are maintained by the Ocean Protocol Foundation and others.
+You can test an Ocean Protocol application (such as a marketplace) against the test networks (testnets) described below.
 
-## Kovan Testnet
+## The Kovan Testnet
 
-The [Kovan Testnet](https://github.com/kovan-testnet/proposal) (or just "Kovan") is a public Ethereum testnet operated by members of the Ethereum community. The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-contracts) (smart contracts) are deployed there.
+The [Kovan Testnet](https://github.com/kovan-testnet/proposal) (or just "Kovan") is a public Ethereum testnet operated by members of the Ethereum community.
 
-Moreover, there is a [Secret Store](/concepts/components/#secret-store) operated by the Ocean Protocol Foundation which is connected to the Kovan Testnet.
+### Kovan Blockchain Explorers
 
-## Nile Testnet
+There are some Kovan blockchain explorers, e.g. [Etherscan for Kovan](https://kovan.etherscan.io/) and [BlockScout for Kovan](https://blockscout.com/eth/kovan). You can use those to check the status of a transaction, the balance of an account, and more.
 
-_Formerly called the Ocean POA Tesnet._
+### Keeper Contracts on Kovan
 
-The Nile Testnet is similar to the Kovan Testnet, except all the nodes are operated by the Ocean Protocol Foundation. The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-contracts) (smart contracts) are deployed there.
+The Ocean Protocol [keeper contracts](https://github.com/oceanprotocol/keeper-contracts) (smart contracts) are deployed on Kovan. In fact, several versions of the keeper contracts have been deployed there. You can find the addresses of recently-deployed keeper contracts (including the OceanToken contract) as follows:
 
-Moreover, there is a [Secret Store](/concepts/components/#secret-store) operated by the Ocean Protocol Foundation which is connected to the Nile Testnet.
+1. Go to [the list of keeper-contracts releases (Git tags) on GitHub](https://github.com/oceanprotocol/keeper-contracts/releases).
+1. Click on the name of a release's Git tag in the left sidebar. It will look something like `v0.8.3`.
+1. Scroll down to the **Kovan Testnet** section of the README.md file. The contract addresses are listed there. Note: Sometimes there is a disconnect between the release number and the listed version number.
 
-## Spree Testnet
+Note: Because Ocean Protocol uses ZeppelinOS to manage smart contract upgrades, a keeper contract address might not change over time (because it's just the address _of the proxy contract_) but the actually-used smart contract might change, along with its functionality.
+
+_At the time of writing_, the contract address of the OceanToken contract in Kovan was:
+
+0x963f52e2f4827ef82c56ad2eb81f650f66aeb267
+
+### Ocean Components Connected to Kovan
+
+There is a [Secret Store](/concepts/components/#secret-store) connected to the Kovan Testnet for use by Ocean Protocol projects (including your projects). It's operated by BigchainDB GmbH. Its URL is:
+
+[https://secret-store-kovan.dev-ocean.com/](https://secret-store-kovan.dev-ocean.com/)
+
+Aside from the Secret Store, there is no other Ocean Protocol software component (e.g. Aquarius) that is live, connected to the Kovan testnet, and operated by BigchainDB GmbH.
+
+## The Nile Testnet
+
+_Formerly called the Ocean POA Testnet._
+
+The Nile Testnet is similar to the Kovan Testnet, except all the nodes are operated by BigchainDB GmbH.
+If you want to connect to the Nile Testnet e.g. using MetaMask, then you must enter an "RPC URL" for the Nile Testnet. It is:
+
+[https://nile.dev-ocean.com/](https://nile.dev-ocean.com/)
+
+(You don't need to include the port number.)
+
+### Nile Blockchain Explorers
+
+There is a Nile blockchain explorer at [https://submarine.dev-ocean.com/](https://submarine.dev-ocean.com/). You can use it to check the status of a transaction, the balance of an account, and more. It uses the following symbols for Nile Ether and Ocean Tokens:
+
+Cryptocurrency    | Symbol used
+------------------|------------
+Nile Ether        | POA
+Nile Ocean Tokens | SBT-OCN
+
+### Keeper Contracts on Nile
+
+See the subsection about the [Keeper Contracts on Kovan](#keeper-contracts-on-kovan). The Nile contract addresses can be found in the same way.
+
+_At the time of writing_, the contract address of the OceanToken contract in Nile was:
+
+0x5b39858a450e8b51b5dcc598aafc4045c499d14f
+
+### Ocean Components Connected to Nile
+
+There are several Ocean Protocol software components that are live, connected to the Nile testnet, and operated by BigchainDB GmbH:
+
+- Secret Store at [https://secret-store.dev-ocean.com](https://secret-store.dev-ocean.com)
+- Aquarius at [https://nginx-aquarius.dev-ocean.com](https://nginx-aquarius.dev-ocean.com)
+- Brizo at [https://nginx-brizo.dev-ocean.com](https://nginx-brizo.dev-ocean.com)
+- Jupyter Hub at [https://mantaray.dev-ocean.com](https://mantaray.dev-ocean.com)
+- [Token Bridge Frontend](https://github.com/oceanprotocol/bridge-ui) (for a token bridge between Nile and Kovan) at [https://token-bridge.dev-ocean.com](https://token-bridge.dev-ocean.com)
+
+> Internal note: The private "atlantic" repo documents the internal details of the Nile testnet in `networks/nile/README.md`.
+
+## A Spree Testnet
 
 When Ocean Protocol developers run [Barge](https://github.com/oceanprotocol/barge) with the `--local-spree-node` option, a "Spree Testnet" node is deployed on their local machine: a local "testnet" not connected to any public testnet. It's named after the main river flowing through Berlin, Germany, where many Ocean Protocol developers are located.
 
-## Technical Details about the Public Testnets
-
-- [Details about the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/secret-store-cluster.md) (which is called the "Parity Secret Store Cluster" on that page).
-- [Addresses of the keeper contracts](https://github.com/oceanprotocol/keeper-contracts#testnet-deployment) (smart contracts) deployed in the public testnets (and more).
+Spree testnet details can be found in the [Barge README.md file](https://github.com/oceanprotocol/barge/blob/develop/README.md).


### PR DESCRIPTION
For the Kovan and Nile testnets, I added details such as:

- the RPC URL (for Nile only, MetaMask and similar already know the Kovan RPC URL)
- Links to blockchain explorers
- How to figure out the keeper contract addresses
- Other Ocean components connected to the network in question, and their URLs

Resolves #170 