### PR TITLE
Unlink the "Computing Services" page (for now)

### DIFF
--- a/data/sidebars/concepts.yml
+++ b/data/sidebars/concepts.yml
@@ -19,8 +19,6 @@
       link: /concepts/architecture/
     - title: Secret Store
       link: /concepts/secret-store/
-    - title: Computing Services
-      link: /concepts/computing-services/
 
 - group: Contribute
   items:


### PR DESCRIPTION
because the way that "computing services" work in Ocean will be different now (after the big refactor of the keeper contracts), but it hasn't been updated yet.

Computing Services are not really an option right now anyway, so it's safe to remove the page about it from the docs.