### PR TITLE
Document Commons Marketplace and Update Marketplace Setup Guide

### DIFF
--- a/content/concepts/components.md
+++ b/content/concepts/components.md
@@ -5,6 +5,28 @@ description: The Ocean Protocol network is brought to life by many interacting s
 
 Before reading this page, you should understand some [Ocean-specific terminology](/concepts/terminology/).
 
+## Keeper
+
+A computer running a blockchain client
+(such as [Parity Ethereum](https://www.parity.io/ethereum/))
+where the associated blockchain network is running the Ocean Protocol
+[keeper-contracts](https://github.com/oceanprotocol/keeper-contracts)
+(smart contracts).
+
+<repo name="keeper-contracts"></repo>
+
+See also: [Run a Keeper](/setup/keeper/)
+
+## Secret Store
+
+A [Parity Secret Store](https://wiki.parity.io/Secret-Store): software for distributed key pair generation, distributed key storage, and threshold retrieval. It's used to store [asset](/concepts/terminology/#asset-or-data-asset) access-control keys.
+
+There are several clients for integrating the Parity Secret Store into Ocean:
+
+<repo name="secret-store-client-js"></repo>
+<repo name="secret-store-client-py"></repo>
+<repo name="secret-store-client-java"></repo>
+
 ## Aquarius
 
 Marketplaces run Aquarius to store and manage metadata about the [assets](/concepts/terminology/#asset-or-data-asset) available in their marketplace. It provides an HTTP API for interacting with an off-chain database (sometimes called "OceanDB").
@@ -35,24 +57,6 @@ Brizo supports several options for file storage, including Azure Storage, Amazon
 <repo name="osmosis-aws-driver"></repo>
 <repo name="osmosis-on-premise-driver"></repo>
 
-## Keeper
-
-A computer running a blockchain client
-(such as [Parity Ethereum](https://www.parity.io/ethereum/))
-where the associated blockchain network is running the Ocean Protocol
-[💧 keeper-contracts](https://github.com/oceanprotocol/keeper-contracts)
-(smart contracts).
-
-<repo name="keeper-contracts"></repo>
-
-See also: [Run a Keeper](/setup/keeper/)
-
-## Pleuston
-
-An example marketplace front-end for consumers to explore, download, and publish [assets](/concepts/terminology/#asset-or-data-asset) within the Ocean Protocol network. Implemented using [React](https://reactjs.org/) and [🦑 squid-js](https://github.com/oceanprotocol/squid-js).
-
-<repo name="pleuston"></repo>
-
 ## Squid Libraries
 
 Client libraries used by applications (such as Pleuston or Jupyter notebooks) to interact with Ocean components, including Keepers, Aquarius nodes, Brizo nodes, etc.
@@ -63,12 +67,16 @@ Client libraries used by applications (such as Pleuston or Jupyter notebooks) to
 <repo name="squid-py"></repo>
 <repo name="squid-java"></repo>
 
-## Secret Store
+## Pleuston
 
-A [Parity Secret Store](https://wiki.parity.io/Secret-Store): software for distributed key pair generation, distributed key storage, and threshold retrieval. It's used to store [asset](/concepts/terminology/#asset-or-data-asset) access-control keys.
+An example marketplace/publisher front-end for developers to explore, download, and publish [assets](/concepts/terminology/#asset-or-data-asset) in an Ocean Protocol network. Implemented using [React](https://reactjs.org/) and [squid-js](https://github.com/oceanprotocol/squid-js).
 
-There are several clients for integrating the Parity Secret Store into Ocean:
+<repo name="pleuston"></repo>
 
-<repo name="secret-store-client-js"></repo>
-<repo name="secret-store-client-py"></repo>
-<repo name="secret-store-client-java"></repo>
+## Commons Marketplace
+
+An online example marketplace/publisher for consumers to explore, download, and publish open data sets in the [Nile Testnet](/concepts/testnets/#the-nile-testnet). Implemented using [React](https://reactjs.org/) and [squid-js](https://github.com/oceanprotocol/squid-js).
+
+For more information, see [the blog post about Commons Marketplace](https://blog.oceanprotocol.com/the-commons-data-marketplace-c57a44288314).
+
+<repo name="commons"></repo>

--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -25,7 +25,7 @@ Someone who wants assets. An example is a data scientist working at an economic 
 
 ## Marketplace
 
-A service where publishers can list what assets they have, and consumers can see what's available then buy it (or get it for free). The Ocean network supports many marketplaces/tribes.
+A service where publishers can list what assets they have, and consumers can see what's available then buy it (or get it for free). Every marketplace has a database where they store metadata about the assets they know about (but not the assets themselves). The Ocean network supports many marketplaces/tribes.
 
 ## Verifier
 

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -58,6 +58,7 @@ There are several Ocean Protocol software components that are live, connected to
 - Brizo at [https://nginx-brizo.dev-ocean.com](https://nginx-brizo.dev-ocean.com)
 - Jupyter Hub at [https://mantaray.dev-ocean.com](https://mantaray.dev-ocean.com)
 - [Token Bridge Frontend](https://github.com/oceanprotocol/bridge-ui) (for a token bridge between Nile and Kovan) at [https://token-bridge.dev-ocean.com](https://token-bridge.dev-ocean.com)
+- Commons Marketplace at [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)
 
 > Internal note: The private "atlantic" repo documents the internal details of the Nile Testnet in `networks/nile/README.md`.
 

--- a/content/setup/marketplace.md
+++ b/content/setup/marketplace.md
@@ -1,20 +1,16 @@
 ---
 title: Set Up a Marketplace
-description: Set up and run a data marketplace in the Ocean network.
+description: Set up and run a data marketplace in an Ocean network.
 ---
 
-## What Does it Mean to Set Up a Marketplace?
+In Ocean Protocol, marketplaces and publishers play different roles (outlined in the [Terminology page](/concepts/terminology/)), but both roles can be played by the same person or organization. Initially, we anticipate that will be the most common setup. As a result, this guide explains how to set up and run a combined marketplace/publisher (for now).
 
-An Ocean marketplace app is one of the primary ways that end users use the Ocean network. For example, a data scientist could use a marketplace app to see what [assets](/concepts/terminology/#asset-or-data-asset) a marketplace has available. They can use the marketplace app to buy access to assets. Publishers make those assets available.
-
-**Note: In the early days of the Ocean network, there won't be many marketplaces or publishers, so marketplaces will often also act as publishers.**
-
-If you want to set up and run a marketplace in the Ocean network, then at a technical level, you must:
+## An Outline of the Steps
 
 1. Have [assets](/concepts/terminology/#asset-or-data-asset) to offer in your marketplace.
-1. Get those assets set up to work with Ocean Protocol.
-1. Develop a marketplace application (app).
-1. Run your marketplace app in production.
+1. Prepare those assets to work with Ocean Protocol.
+1. Develop a marketplace/publisher app.
+1. Run everything you need to run in production.
 
 ## Prepare Assets
 
@@ -28,22 +24,21 @@ Note: You can use _all_ of the above. You aren't restricted to using only one st
 
 Support for other kinds of assets (e.g. computing in Azure) is coming.
 
-## Develop a Marketplace App
+## Develop a Marketplace/Publisher App
 
-At the time of writing, we recommend the following steps to develop a marketplace app:
+At the time of writing, we recommend the following steps to develop a marketplace/publisher app:
 
 1. Do the [React App Tutorial](/tutorials/react-setup/).
 1. Grow your app from there.
 
-For inspiration, check out [the source code for Pleuston](https://github.com/oceanprotocol/pleuston), a demo marketplace app (also written using React). It has an Apache v2 open source license.
+For more examples and inspiration, check out [the source code for Pleuston](https://github.com/oceanprotocol/pleuston) and the [the source code for the Commons Marketplace](https://github.com/oceanprotocol/commons). Both have an Apache v2 open source license. Both use React and squid-js. Both are "serverless" apps: they run entirely in the browser and have no server-side component.
 
 <repo name="pleuston"></repo>
+<repo name="commons"></repo>
 
-Note that Pleuston is a "serverless" app: it runs entirely in the browser and has no server-side component.
+### Other Options
 
-### Other Options for Developing a Marketplace App
-
-There are many ways to create an Ocean marketplace app. For example, you could use one of the existing e-commerce platforms and frameworks (e.g. WooCommerce, Magento, Shopify). Or you could use a lower-level framework like Django or Vue.js. The main consideration is that you should probably use a programming language with an existing Squid library.
+A marketplace/publisher app could have both a back-end component and a front-end component. The main consideration is that you should probably use a programming language with an existing Squid library:
 
 <repo name="squid-js"></repo>
 <repo name="squid-py"></repo>
@@ -53,15 +48,20 @@ Note: There are examples of how to use squid-py in the [Tutorials](/tutorials/in
 
 Of course, you could always write your own Squid library in the language of your choice.
 
-## Run Your Marketplace App in Production
+## Run Everything You Need to Run in Production
 
-The Ocean Mainnet is slated to go live in March 2019.
+When developing your marketplace/publisher app, you will probably use Barge to run all the Ocean Protocol components on your local machine. When it comes time to go to production, you will have to run some of those components in production:
 
-Before running your marketplace app in production with the Ocean Mainnet, you may want to test it with an [Ocean testnet](/concepts/testnets/).
-The Ocean testnets are similar to the Ocean Mainnet.
-The main difference is that there is less risk on the Ocean testnets.
+- Your marketplace/publisher app
+- [Aquarius](/concepts/components/#aquarius)
+- A database to go with Aquarius, e.g. MongoDB or Elasticsearch
+- [Brizo](/concepts/components/#brizo)
+- Recommended: a [keeper](/concepts/components/#keeper) node with the keeper contracts deployed to it, connected to an Ocean network
+- Optional: your own [Secret Store](/concepts/components/#secret-store) nodes (for a more advanced setup)
 
-Of course, there are many other things that must be handled for live production apps:
+Before running all of that in production with the Ocean Mainnet, you will want to test it with an [Ocean testnet](/concepts/testnets/).
+
+Of course, there are many other things that must be handled in production:
 
 - Security of the infrastructure where the software is running
 - Monitoring

--- a/content/setup/publisher.md
+++ b/content/setup/publisher.md
@@ -1,10 +1,6 @@
 ---
-title: Publish Data or Services
-description: How to operate as a publisher in the Ocean network.
+title: Set Up a Publisher
+description: Set up and run a publisher in an Ocean network.
 ---
-
-Suppose a data scientist purchased a license to use a particular data set. Then they must go through a publisher to get the actual data set. It might be stored on Azure. The publisher would hold the Azure access keys, and would do the checks necessary to ensure that the data scientist has access before letting them get the data set.
-
-Publishers should run Brizo and a Keeper node.
 
 Initially, there won't be many Ocean marketplaces or publishers, so most marketplaces will also act as publishers, and most publishers will also act as marketplaces. Therefore, for now, see [the docs for marketplaces](/setup/marketplace/).

--- a/content/tutorials/example-code.md
+++ b/content/tutorials/example-code.md
@@ -12,6 +12,8 @@ description: Examples of code using the Squid libraries.
 ## squid-js Examples
 
 - [The React App Tutorial](/tutorials/react-setup/)
+- [The Pleuston source code](https://github.com/oceanprotocol/pleuston)
+- [The Commons Marketplace source code](https://github.com/oceanprotocol/commons)
 - [The src/examples/ directory of the squid-js repository](https://github.com/oceanprotocol/squid-js/tree/develop/src/examples)
 - [The squid-js tests](https://github.com/oceanprotocol/squid-js/tree/develop/test)
 

--- a/data/sidebars/setup.yml
+++ b/data/sidebars/setup.yml
@@ -10,7 +10,7 @@
 
 - group: Publishers
   items:
-    - title: Publish Data or Services
+    - title: Set Up a Publisher
       link: /setup/publisher/
 
 - group: Keepers


### PR DESCRIPTION
- The Commons Marketplace is "new" (to the outside world) so I added documentation about it and links to it in many places.
- I re-ordered the components in the **Components** page to better-reflect the L1, L2, L3 way we think of them. I also added an entry about Commons Marketplace there.
- I realized that Pleuston and Commons Marketplace are really a front-end for a _combined_ marketplace/publisher, i.e. they are not just a front-end for a marketplace. (One can also use them to publish assets.)
- I re-did a lot of the Marketplace Setup Guide. Maybe that should have been done in its own pull request, but the Commons Marketplace is a key example of a marketplace/publisher app and so I had to mention it, and then I got carried away.
- I also deleted the sentence, "The Ocean Mainnet is slated to go live in March 2019."