### PR TITLE
Update the 'Run a Keeper' page

### DIFF
--- a/content/setup/keeper.md
+++ b/content/setup/keeper.md
@@ -1,13 +1,21 @@
 ---
 title: Run a Keeper
-description: How to Run a Keeper node in the Ocean network.
+description: How to run a keeper node.
 ---
 
-The Nile Testnet is an Ethereum [Proof-of-Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains) where all the nodes (Keeper nodes) are running [Parity Ethereum](https://www.parity.io/ethereum/).
-There are two kinds of Keeper nodes in the Nile Testnet: authority nodes (voting nodes) and user nodes (non-voting nodes).
+If you want to run a [keeper node (keeper)]((/concepts/components/#keeper)), you have several options. Some of them are outlined below.
 
-Authority nodes have a say in determining which transactions are valid. In the Nile Testnet, the authority nodes are run by BigchainDB GmbH and its partners. If you're interested in running an authority node in the Nile Testnet, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
+## Using Barge
 
-Anyone can run a user node. It will stay in sync with the other nodes in the Nile Testnet, it just won't have a say on whether transactions are valid.
-Marketplaces and publishers should run user nodes.
-See the pages for [marketplaces](/setup/marketplace/) and [publishers](/setup/publisher/).
+[Barge](https://github.com/oceanprotocol/barge) uses Docker Compose to run one or more keeper nodes (and other components) in Docker containers on your local machine.
+
+- If you use `--local-kovan-node` or `--local-nile-node`, then it will run one local Parity Ethereum node (as a _user node_, i.e. a non-voting node) and it will connect that node to the [Kovan Testnet](/concepts/testnets/#the-kovan-testnet) or [Nile Testnet](/concepts/testnets/#the-nile-testnet), respectively.
+- If you use `--local-spree-node` or `--local-ganache-node`, then it will run a strictly-local [Spree Testnet](/concepts/testnets/#a-spree-testnet-for-local-development) or [Ganache-Based Testnet](http://localhost:8000/concepts/testnets/#a-ganache-based-testnet-for-local-development).
+
+Barge deploys the keeper contracts to whatever keeper nodes are deployed locally.
+
+## Running a Keeper in the Nile Testnet or Ocean Mainnet
+
+If you're interested in running a keeper node (as a voting _authority node_) in the Nile Testnet or Ocean Mainnet, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
+
+Note: The dev-ocean repository contains [a guide for running a keeper node in the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/nile-keeper-setup.md) (if you have permission).


### PR DESCRIPTION
- Outline how Barge can run a keeper (or several) locally
- Tell them to email us if they want to run a keeper in the Nile Testnet or Ocean Mainnet
- Link to our guide on running a keeper node in the Nile Testnet (now public, in dev-ocean)
