### PR TITLE
Add faucet UI to Get Ether doc

### DIFF
--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -59,6 +59,7 @@ There are several Ocean Protocol software components that are live, connected to
 - Jupyter Hub at [https://mantaray.dev-ocean.com](https://mantaray.dev-ocean.com)
 - [Token Bridge Frontend](https://github.com/oceanprotocol/bridge-ui) (for a token bridge between Nile and Kovan) at [https://token-bridge.dev-ocean.com](https://token-bridge.dev-ocean.com)
 - Commons Marketplace at [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)
+- Faucet Server at [faucet.nile.dev-ocean.com](https://faucet.nile.dev-ocean.com)
 
 > Internal note: The private "atlantic" repo documents the internal details of the Nile Testnet in `networks/nile/README.md`.
 

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -25,17 +25,23 @@ You can get Kovan Ether (KEth), for the Kovan Testnet, from a Kovan faucet: see 
 
 ### Get Ether for the Nile Testnet
 
-If you're connecting to the Nile testnet, you can use the faucet UI, which is setup for Nile:
+If you're connecting to the Nile testnet, you can use the Ocean Faucet. A simple UI for it is deployed as part of the Commons marketplace under:
 
-- [commons.oceanprotocol.com/faucet](https://commons.oceanprotocol.com/faucet)
+- client: [commons.oceanprotocol.com/faucet](https://commons.oceanprotocol.com/faucet)
 
-Alternatively, you can send get some Nile Ether in `<YOUR ADDRESS>` using the following command (a long command that wraps around):
+This interface is setup to communicate with the deployed Ocean Faucet Server under:
+
+- server: [faucet.nile.dev-ocean.com](https://faucet.nile.dev-ocean.com)
+
+You can also communicate with that server directly and get some Nile Ether into `<YOUR ADDRESS>` using the following command:
 
 ```bash
-curl --data '{"address": "<YOUR ADDRESS>", "agent": "curl"}' -H "Content-Type: application/json"  -X POST https://faucet.nile.dev-ocean.com/faucet
+curl --data '{"address": "<YOUR ADDRESS>", "agent": "curl"}' -H "Content-Type: application/json" -X POST https://faucet.nile.dev-ocean.com/faucet
 ```
 
 In the above command you only need to replace `<YOUR ADDRESS>` with your own Ethereum address.
+
+Check out the [Ocean Faucet Server repository](https://github.com/oceanprotocol/faucet) to learn more about what the server provides.
 
 The Nile faucet has a limit of one request every 24 hours for the same Ethereum address. But don't worry, the Ether given is more than enough for interacting with the network.
 

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -29,7 +29,7 @@ If you're connecting to the Nile testnet, you can use the Ocean Faucet. A simple
 
 - client: [commons.oceanprotocol.com/faucet](https://commons.oceanprotocol.com/faucet)
 
-This interface is setup to communicate with the deployed Ocean Faucet Server under:
+This interface is set up to communicate with the deployed Ocean Faucet Server under:
 
 - server: [faucet.nile.dev-ocean.com](https://faucet.nile.dev-ocean.com)
 

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -25,11 +25,18 @@ You can get Kovan Ether (KEth), for the Kovan Testnet, from a Kovan faucet: see 
 
 ### Get Ether for the Nile Testnet
 
-If you're connecting to the Nile testnet, then you can send get some Nile Ether in `<YOUR ADDRESS>` using the following command (a long command that wraps around):
+If you're connecting to the Nile testnet, you can use the faucet UI, which is setup for Nile:
 
-`curl -XPOST --data '{"address": "<YOUR ADDRESS>", "agent": "curl"}' -H "Content-Type: application/json" https://faucet.nile.dev-ocean.com/faucet`
+- [commons.oceanprotocol.com/faucet](https://commons.oceanprotocol.com/faucet)
+
+Alternatively, you can send get some Nile Ether in `<YOUR ADDRESS>` using the following command (a long command that wraps around):
+
+```bash
+curl --data '{"address": "<YOUR ADDRESS>", "agent": "curl"}' -H "Content-Type: application/json"  -X POST https://faucet.nile.dev-ocean.com/faucet
+```
 
 In the above command you only need to replace `<YOUR ADDRESS>` with your own Ethereum address.
+
 The Nile faucet has a limit of one request every 24 hours for the same Ethereum address. But don't worry, the Ether given is more than enough for interacting with the network.
 
 ### Get Ether for a Local Ganache-Based Testnet
@@ -40,7 +47,9 @@ If you're running a local Ganache-based testnet, then it creates several account
 
 **Option 1:** If you're running a local Spree testnet, then you can send some Spree Ether to `<YOUR ADDRESS>` using the following command (a long command that wraps around):
 
-`curl --data '{"jsonrpc":"2.0","method":"personal_sendTransaction","params":[{"from":"0x00Bd138aBD70e2F00903268F3Db08f2D25677C9e","to":"<YOUR ADDRESS>","value":"0x7FFFFFFFFFFFFFFFFFF"}, "node0"],"id":0}' -H "Content-Type: application/json" -X POST localhost:8545`
+```bash
+curl --data '{"jsonrpc":"2.0","method":"personal_sendTransaction","params":[{"from":"0x00Bd138aBD70e2F00903268F3Db08f2D25677C9e","to":"<YOUR ADDRESS>","value":"0x7FFFFFFFFFFFFFFFFFF"}, "node0"],"id":0}' -H "Content-Type: application/json" -X POST localhost:8545
+```
 
 That command uses [Ethereum's JSON RPC API](https://wiki.parity.io/JSONRPC.html). You can also create a new account using the Parity Ethereum CLI. See [the Parity Ethereum CLI documentation](https://wiki.parity.io/CLI-Sub-commands).
 
@@ -54,7 +63,9 @@ Details about the bootstrapped accounts can be found in [the README.md file in t
 
 **Option 3:** Another option is to run [the Ocean faucet server](https://github.com/oceanprotocol/faucet) on your machine, with default configuration settings. The default settings enable it to dispense Spree Ether. To ask the faucet to send some Spree Ether to `<YOUR ADDRESS>`, use the command (a long command that wraps around):
 
-`curl --data '{"address":"<YOUR ADDRESS>"}' -H "Content-Type: application/json" -X POST localhost:3001/faucet`
+```bash
+curl --data '{"address":"<YOUR ADDRESS>"}' -H "Content-Type: application/json" -X POST localhost:3001/faucet
+```
 
 ## Get Ocean Tokens
 


### PR DESCRIPTION
Mention the faucet UI deployed within the commons marketplace as the preferred way of getting Ether for Nile. Also update faucet code examples to be consistent.