### PR TITLE
Updates following the initial exchange offering

### DIFF
--- a/content/concepts/ocean-tokens.md
+++ b/content/concepts/ocean-tokens.md
@@ -21,7 +21,7 @@ There are Ocean Tokens in several testnets, including the Kovan testnet and Nile
 
 **NOTICE: Below we outline the plans for Mainnet Ocean Tokens at the time of writing. Those plans might change. We will update this page on a regular basis.**
 
-The initial circulating supply of Mainnet Ocean Tokens will first become available on the Ethereum Mainnet (_not_ the Ocean Mainnet).
+The initial circulating supply of Mainnet Ocean Tokens became available on the Ethereum Mainnet (_not_ the Ocean Mainnet) in May 2019.
 
 If you acquired Ocean Tokens in the initial circulating supply, they will be sent to the address you provided.
 

--- a/content/setup/keeper.md
+++ b/content/setup/keeper.md
@@ -3,7 +3,7 @@ title: Run a Keeper
 description: How to run a keeper node.
 ---
 
-If you want to run a [keeper node (keeper)]((/concepts/components/#keeper)), you have several options. Some of them are outlined below.
+If you want to run a [keeper node (keeper)](/concepts/components#keeper), you have several options. Some of them are outlined below.
 
 ## Using Barge
 

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -77,6 +77,20 @@ curl --data '{"address":"<YOUR ADDRESS>"}' -H "Content-Type: application/json" -
 
 See the page about [Ocean Tokens](/concepts/ocean-tokens/).
 
+### Get Testnet Ocean Tokens
+
+All Squid libraries have methods to request Ocean Tokens. They work by calling the "Dispenser" keeper contract, a contract which is only deployed to testnets. Therefore they will only work in testnets. They're documented in the following places:
+
+- The squid-js docs for:
+  - [OceanAccounts.requestTokens()](/references/squid-js/#OceanAccounts-requestTokens)
+  - [Account.requestTokens()](/references/squid-js/#Account-requestTokens)
+- The squid-py docs for:
+  - [the `squid_py.ocean.ocean_tokens` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_tokens.html): see the `request()` method.
+  - [the `squid_py.ocean.ocean_accounts` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_accounts.html): see the `request_tokens()` method.
+- [The squid-java docs](https://www.javadoc.io/doc/com.oceanprotocol/squid/): click "All Classes" then "AccountsManager" then scroll to the bottom of the Class AccountsManager page where you'll find the `requestTokens()` method.
+
+The [Example Code page](/tutorials/example-code/) has links to example Squid code (in all of the languages), including examples of using the above methods.
+
 ### Get Mainnet Ocean Tokens
 
 There were several ways to acquire some of the Mainnet Ocean Tokens in the initial circulating supply, including:
@@ -94,17 +108,3 @@ As of 7 May 2019, there was one exchange in the official list of exchanges listi
 In the future, the Ocean Mainnet will be launched and later it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Mainnet.
 
 In the future, it will become possible to earn Mainnet Ocean Tokens as network rewards and in other ways. The [Ocean Protocol Technical Whitepaper](https://oceanprotocol.com/tech-whitepaper.pdf) gives more details.
-
-### Get Testnet Ocean Tokens
-
-All Squid libraries have methods to request Ocean Tokens. They work by calling the "Dispenser" keeper contract, a contract which is only deployed to testnets. Therefore they will only work in testnets. They're documented in the following places:
-
-- The squid-js docs for:
-  - [OceanAccounts.requestTokens()](/references/squid-js/#OceanAccounts-requestTokens)
-  - [Account.requestTokens()](/references/squid-js/#Account-requestTokens)
-- The squid-py docs for:
-  - [the `squid_py.ocean.ocean_tokens` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_tokens.html): see the `request()` method.
-  - [the `squid_py.ocean.ocean_accounts` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_accounts.html): see the `request_tokens()` method.
-- [The squid-java docs](https://www.javadoc.io/doc/com.oceanprotocol/squid/): click "All Classes" then "AccountsManager" then scroll to the bottom of the Class AccountsManager page where you'll find the `requestTokens()` method.
-
-The [Example Code page](/tutorials/example-code/) has links to example Squid code (in all of the languages), including examples of using the above methods.

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -79,14 +79,21 @@ See the page about [Ocean Tokens](/concepts/ocean-tokens/).
 
 ### Get Mainnet Ocean Tokens
 
-There are several ways to acquire some of the Ocean Tokens in the initial circulating supply, including:
+There were several ways to acquire some of the Mainnet Ocean Tokens in the initial circulating supply, including:
 
 - participation in the seed round
 - participation in the pre-sale
 - participation in the token sale
+- participation in the initial exchange offering
 - completion of a [bounty](/concepts/bounties/)
 
-In the future, it will become possible to earn Mainnet Ocean Tokens as network rewards. The [Ocean Protocol Technical Whitepaper](https://oceanprotocol.com/tech-whitepaper.pdf) explains that in more detail.
+After [the initial exchange offering on Bittrex International](https://blog.oceanprotocol.com/initial-exchange-offering-of-ocean-protocol-on-bittrex-international-a454688f466a), Mainnet Ocean Tokens became available in the Ethereum Mainnet (_not_ the Ocean Mainnet; there was no Ocean Mainnet at the time).
+
+As of 7 May 2019, there was one exchange in the official list of exchanges listing Mainnet Ocean Tokens (in the Ethereum Mainnet): **Bittrex International**.
+
+In the future, the Ocean Mainnet will be launched and later it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Mainnet.
+
+In the future, it will become possible to earn Mainnet Ocean Tokens as network rewards and in other ways. The [Ocean Protocol Technical Whitepaper](https://oceanprotocol.com/tech-whitepaper.pdf) gives more details.
 
 ### Get Testnet Ocean Tokens
 

--- a/content/tutorials/wallets-and-ocean-tokens.md
+++ b/content/tutorials/wallets-and-ocean-tokens.md
@@ -35,6 +35,12 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local S
 - `$HOME/.ocean/keeper-contracts/artifacts/OceanToken.spree.json` for Spree
 - `$HOME/.ocean/keeper-contracts/artifacts/OceanToken.development.json` for Ganache
 
+### Ethereum Mainnet
+
+The Ocean Token contract address in the Ethereum Mainnet is:
+
+`0x985dd3D42De1e256d09e1c10F112bCCB8015AD41`
+
 ## Step 2: Teach Your Wallet Software about Ocean Tokens
 
 ### MetaMask Instructions


### PR DESCRIPTION
- Provide the Ethereum contract address of Ocean Tokens in the Ethereum Mainnnet.
- Give the official list of exchanges listing Mainnet Ocean Tokens (as of 7 May 2019). I asked Sarah what we can say about exchanges and this is all we can say right now.
- Expand the subsection about getting Mainnet Ocean Tokens, and change the ordering to testnets-then-mainnet (for consistency with the rest of the docs)
- Also fix a broken internal hyperlink