### PR TITLE
Update the page with links to example squid code

### DIFF
--- a/content/tutorials/example-code.md
+++ b/content/tutorials/example-code.md
@@ -14,8 +14,9 @@ description: Examples of code using the Squid libraries.
 - [The React App Tutorial](/tutorials/react-setup/)
 - [The Pleuston source code](https://github.com/oceanprotocol/pleuston)
 - [The Commons Marketplace source code](https://github.com/oceanprotocol/commons)
-- [The src/examples/ directory of the squid-js repository](https://github.com/oceanprotocol/squid-js/tree/develop/src/examples)
-- [The squid-js tests](https://github.com/oceanprotocol/squid-js/tree/develop/test)
+- The squid-js tests:
+  - [Unit tests](https://github.com/oceanprotocol/squid-js/tree/develop/test)
+  - [Integration tests](https://github.com/oceanprotocol/squid-js/tree/develop/integration/ocean)
 
 ## squid-java Examples
 


### PR DESCRIPTION
- Removed the link to the squid-js `src/examples` directory because it is gone now, following https://github.com/oceanprotocol/squid-js/pull/231
- Added a link to the squid-js integration tests (in addition to the link to the unit tests, which was already in the docs).
- I don't think Tuna is easy for an outsider to use yet, so there are no links to Tuna. (The Tuna README.md file hasn't been updated since December.)