### PR TITLE
Update terminology re/ Ocean Production Network

### DIFF
--- a/content/concepts/introduction.md
+++ b/content/concepts/introduction.md
@@ -22,4 +22,3 @@ Society is becoming increasingly reliant on data, especially with the advent of 
 Ocean Protocol aims to unlock data, for more equitable outcomes for users of data, using a thoughtful application of both technology and governance.
 
 For more details, see the blog post "[Mission & Values for Ocean Protocol](https://blog.oceanprotocol.com/mission-values-for-ocean-protocol-aba998e95b8)".
-

--- a/content/concepts/ocean-tokens.md
+++ b/content/concepts/ocean-tokens.md
@@ -3,6 +3,8 @@ title: Ocean Tokens
 description: The technical basics of Ocean Tokens.
 ---
 
+**NOTICE: Below we outline some plans at the time of writing. Those plans might change. We will update this page on a regular basis.**
+
 ## Basics
 
 **Ocean Tokens** are the [cryptocurrency](https://en.wikipedia.org/wiki/Cryptocurrency) associated with Ocean Protocol. They are standards-compliant [ERC-20 tokens](https://en.wikipedia.org/wiki/ERC-20).
@@ -17,17 +19,66 @@ description: The technical basics of Ocean Tokens.
 
 There are Ocean Tokens in several testnets, including the Kovan testnet and Nile testnet. They are just testnet Ocean Tokens (i.e. for testing purposes only) and they aren't interchangeable with Ethereum Mainnet Ocean Tokens. For more details, see the the [page about Testnets](/concepts/testnets/) and the [tutorials](/tutorials/introduction/).
 
-## Ocean Tokens in the Ethereum Mainnet and the Ocean Production Network
+### Testnet Ocean Token Utility
 
-**NOTICE: Below we outline plans at the time of writing. Those plans might change. We will update this page on a regular basis.**
+Once you have some Testnet Ocean Tokens, you can use them for all currently-implemented Ocean Protocol tasks _in that testnet_ (e.g. buying assets).
 
-The initial circulating supply of Ethereum Mainnet Ocean Tokens became available on the Ethereum Mainnet (_not_ the [Ocean Production Network](/concepts/production-network/)) in May 2019.
+### Get Testnet Ocean Tokens
 
+All Squid libraries have methods to request Ocean Tokens. They work by calling the "Dispenser" keeper contract, a contract which is only deployed to testnets. Therefore they will only work in testnets. They're documented in the following places:
+
+- The squid-js docs for:
+  - [OceanAccounts.requestTokens()](/references/squid-js/#OceanAccounts-requestTokens)
+  - [Account.requestTokens()](/references/squid-js/#Account-requestTokens)
+- The squid-py docs for:
+  - [the `squid_py.ocean.ocean_tokens` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_tokens.html): see the `request()` method.
+  - [the `squid_py.ocean.ocean_accounts` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_accounts.html): see the `request_tokens()` method.
+- [The squid-java docs](https://www.javadoc.io/doc/com.oceanprotocol/squid/): click "All Classes" then "AccountsManager" then scroll to the bottom of the Class AccountsManager page where you'll find the `requestTokens()` method.
+
+The [Example Code page](/tutorials/example-code/) has links to example Squid code (in all of the languages), including examples of using the above methods.
+
+## Ethereum Mainnet Ocean Tokens
+
+There were several ways to acquire some of the Ethereum Mainnet Ocean Tokens in the initial circulating supply, including:
+
+- participation in the seed round
+- participation in the pre-sale
+- participation in the token sale
+- participation in the initial exchange offering
+- completion of a [bounty](/concepts/bounties/)
+
+After [the initial exchange offering on Bittrex International](https://blog.oceanprotocol.com/initial-exchange-offering-of-ocean-protocol-on-bittrex-international-a454688f466a), Ethereum Mainnet Ocean Tokens became available in the Ethereum Mainnet (_not_ the Ocean Production Network; there was no Ocean Production Network at the time).
+The initial circulating supply of Ethereum Mainnet Ocean Tokens became available on the Ethereum Mainnet in May 2019.
 If you acquired Ocean Tokens in the initial circulating supply, they should have been, or will be, sent to the address you provided, in the Ethereum Mainnet.
 
-In the future, the [Ocean Production Network](/concepts/production-network/) will be launched and later it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Production Network.
+### Ethereum Mainnet Ocean Token Utility
 
-At the time of writing, Ethereum Mainnet Ocean Tokens could not be used for Ocean Protocol tasks (such as purchasing a data set) in the Ethereum Mainnet.
+At the time of writing, you could use Ethereum Mainnet Ocean Tokens to do various things in the Ethereum Mainnet, including but not limited to:
+
+- buy other cryptocurrencies. See the next subsection for more details.
+- stake in [dxDAO](https://dxdao.daostack.io/).
+
+Moreover, in the near future, there are plans to make it possible to use Ethereum Mainnet Ocean Tokens for Ocean Protocol tasks in the Ethereum Mainnet. That includes asset and service acquisition, via Ocean Protocol marketplaces attached to the Ethereum Mainnet.
+
+### How to Buy or Sell Ethereum Mainnet Ocean Tokens
+
+You can buy or sell Ethereum Mainnet Ocean Tokens via any exchange that lists them. See the official list of exchanges below.
+
+You could also make a deal with someone where you send them something and they send you some Ocean Tokens in return (or vice versa). Ethereum Mainnet Ocean Tokens are standard ERC-20 tokens, so any software that can send ERC-20 tokens can be used (e.g. [wallet software](/concepts/wallets/) such as MetaMask).
+
+### Official List of Exchanges
+
+Below is the _official list_ of exchanges which listed Ethereum Mainnet Ocean Tokens (OCEAN), at the time of writing:
+
+- [Bittrex International](https://international.bittrex.com/)
+- [KuCoin](https://www.kucoin.com/)
+- [DutchX](https://dutchx.readthedocs.io/en/latest/)
+
+## Ocean Protuction Network Ocean Tokens
+
+At the time of writing, the [Ocean Production Network](/concepts/production-network/) wasn't deployed yet, so there were no Ocean Protuction Network Ocean Tokens.
+
+At some point after the Ocean Production Network is launched, it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Production Network. The details of exactly how that will work are still to be determined.
 
 ## Further Reading about Ocean Tokens
 

--- a/content/concepts/ocean-tokens.md
+++ b/content/concepts/ocean-tokens.md
@@ -15,19 +15,19 @@ description: The technical basics of Ocean Tokens.
 
 ## Testnet Ocean Tokens
 
-There are Ocean Tokens in several testnets, including the Kovan testnet and Nile testnet. They are just testnet Ocean Tokens (i.e. for testing purposes only) and they aren't interchangeable with Mainnet Ocean Tokens. For more details, see the the [page about Testnets](/concepts/testnets/) and the [tutorials](/tutorials/introduction/).
+There are Ocean Tokens in several testnets, including the Kovan testnet and Nile testnet. They are just testnet Ocean Tokens (i.e. for testing purposes only) and they aren't interchangeable with Ethereum Mainnet Ocean Tokens. For more details, see the the [page about Testnets](/concepts/testnets/) and the [tutorials](/tutorials/introduction/).
 
-## Mainnet Ocean Tokens
+## Ocean Tokens in the Ethereum Mainnet and the Ocean Production Network
 
-**NOTICE: Below we outline the plans for Mainnet Ocean Tokens at the time of writing. Those plans might change. We will update this page on a regular basis.**
+**NOTICE: Below we outline plans at the time of writing. Those plans might change. We will update this page on a regular basis.**
 
-The initial circulating supply of Mainnet Ocean Tokens became available on the Ethereum Mainnet (_not_ the Ocean Mainnet) in May 2019.
+The initial circulating supply of Ethereum Mainnet Ocean Tokens became available on the Ethereum Mainnet (_not_ the [Ocean Production Network](/concepts/production-network/)) in May 2019.
 
-If you acquired Ocean Tokens in the initial circulating supply, they will be sent to the address you provided.
+If you acquired Ocean Tokens in the initial circulating supply, they should have been, or will be, sent to the address you provided, in the Ethereum Mainnet.
 
-In the future, the Ocean Mainnet will be launched and later it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Mainnet.
+In the future, the [Ocean Production Network](/concepts/production-network/) will be launched and later it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Production Network.
 
-It _won't_ be possible to use Mainnet Ocean Tokens for Ocean Protocol tasks (such as consuming assets) in the Ethereum Mainnet. It _will_ be possible to use Mainnet Ocean Tokens for Ocean Protocol tasks in the Ocean Mainnet.
+At the time of writing, Ethereum Mainnet Ocean Tokens could not be used for Ocean Protocol tasks (such as purchasing a data set) in the Ethereum Mainnet.
 
 ## Further Reading about Ocean Tokens
 

--- a/content/concepts/production-network.md
+++ b/content/concepts/production-network.md
@@ -11,7 +11,7 @@ Ocean Protocol makes use of several EVM networks, including:
 - various [testnets](/concepts/testnets/), and
 - in the future, the Ocean Production Network.
 
-The Ocean Production Network will be an EVM network of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software.  Various Ocean Protocol smart contracts ("keeper contracts") will be deployed to it. It will be used for production use cases. It is also known by other names, including:
+The Ocean Production Network will be an EVM network of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software. Various Ocean Protocol smart contracts ("keeper contracts") will be deployed to it. It will be used for production use cases. It is also known by other names, including:
 
 - The Main Ocean Network
 - The Ocean Mainnet

--- a/content/concepts/production-network.md
+++ b/content/concepts/production-network.md
@@ -1,0 +1,28 @@
+---
+title: The Ocean Production Network
+description: An introduction to the Ocean Production Network.
+---
+
+**At the time of writing, there was no live, running, publicly-available Ocean Production Network.**
+
+Ocean Protocol makes use of several EVM networks, including:
+
+- the Ethereum Mainnet (also called the Main Ethereum Network),
+- various [testnets](/concepts/testnets/), and
+- in the future, the Ocean Production Network.
+
+The Ocean Production Network will be an EVM network of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software.  Various Ocean Protocol smart contracts ("keeper contracts") will be deployed to it. It will be used for production use cases. It is also known by other names, including:
+
+- The Main Ocean Network
+- The Ocean Mainnet
+- The Ocean Live Network
+- (among the internal dev team) The Ocean Pacific Network, or just Pacific
+
+"Network" is sometimes shortened to just "Net."
+
+[Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet (and still were, at the time of writing). For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).
+
+
+
+
+TODO: search in files for all references to the Ocean Mainnet etc.

--- a/content/concepts/production-network.md
+++ b/content/concepts/production-network.md
@@ -21,8 +21,3 @@ The Ocean Production Network will be an EVM network of nodes ("keepers") running
 "Network" is sometimes shortened to just "Net."
 
 [Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet (and still were, at the time of writing). For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).
-
-
-
-
-TODO: search in files for all references to the Ocean Mainnet etc.

--- a/content/concepts/resources.md
+++ b/content/concepts/resources.md
@@ -3,7 +3,6 @@ title: Resources
 description: More places where you can learn about Ocean Protocol.
 ---
 
-
 ## Papers
 
 All papers can be retrieved from the [Papers section](https://oceanprotocol.com/protocol/#papers) on our home page:
@@ -76,9 +75,9 @@ Follow [our YouTube channel](https://www.youtube.com/oceanprotocol) not to miss 
   Manta Ray is designed to leverage the underlying Ocean API (oceanically named squid-py) which provides surface level methods for searching, publishing, and consuming assets in the deeper Ocean Protocol network.
 - [Meet the Fleet](https://www.youtube.com/playlist?list=PL_dn0wVs9kWrgEGk0cd52qO6w3FiuY65G) - Ocean Protocol is being built by a diverse ecosystem of contributors who share a common vision of unlocking data for AI. Our core team has converged from many different countries, industries, and backgrounds to collaborate on kickstarting a New Data Economy. Check this mini series to find out who helps developing Ocean Protocol.
 
-## Events 
+## Events
 
-Our team members travel the world to present about Ocean Protocol and meet with local communities. Please, check [our website](https://oceanprotocol.com/#events) for events in your area. 
+Our team members travel the world to present about Ocean Protocol and meet with local communities. Please, check [our website](https://oceanprotocol.com/#events) for events in your area.
 
 We also often host and co-organize meetups all around the globe. Check the different meetup groups to find a group in your city and attend our meetup:
 

--- a/content/concepts/tools.md
+++ b/content/concepts/tools.md
@@ -17,7 +17,7 @@ The [Ocean Protocol Faucet Server](https://github.com/oceanprotocol/faucet) is a
 
 <repo name="faucet"></repo>
 
-## Submarine Blockchain Explorer 
+## Submarine Blockchain Explorer
 
 Submarine is based on [BlockScout](https://github.com/poanetwork/blockscout) (by [POA](https://poa.network/)), an open source blockchain explorer for Ethereum networks.
 

--- a/content/concepts/wallets.md
+++ b/content/concepts/wallets.md
@@ -28,7 +28,7 @@ Once your wallet is set up, it will have one or more **accounts**.
 
 Each account has several **balances**, e.g. an Ether balance, an Ocean Token balance, and maybe other balances. All balances start at zero.
 
-An account's Ether balance might be 7.1 ETH in the Ethereum mainnet, 2.39 ETH in the Kovan testnet, and 0.1 ETH in the Nile testnet. You can't move ETH from one network to another (unless there is a special exchange or bridge set up). The same is true of Ocean Token balances.
+An account's Ether balance might be 7.1 ETH in the Ethereum Mainnet, 2.39 ETH in the Kovan testnet, and 0.1 ETH in the Nile testnet. You can't move ETH from one network to another (unless there is a special exchange or bridge set up). The same is true of Ocean Token balances.
 
 Each account has one **private key**, one **public key** and one **address**. The public key and address can be calculated from the private key. You must keep the private key secret because it's what's needed to spend/transfer Ether and Ocean Tokens (or to sign transactions of any kind). You can share the address with others. In fact, if you want someone to send some Ether or Ocean Tokens to an account, you give them the account's address.
 

--- a/content/setup/keeper.md
+++ b/content/setup/keeper.md
@@ -14,8 +14,8 @@ If you want to run a [keeper node (keeper)](/concepts/components#keeper), you ha
 
 Barge deploys the keeper contracts to whatever keeper nodes are deployed locally.
 
-## Running a Keeper in the Nile Testnet or Ocean Mainnet
+## Running a Keeper in the Nile Testnet or Ocean Production Network
 
-If you're interested in running a keeper node (as a voting _authority node_) in the Nile Testnet or Ocean Mainnet, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
+If you're interested in running a keeper node (as a voting _authority node_) in the [Nile Testnet](/concepts/testnets/#the-nile-testnet) or [Ocean Production Network](http://localhost:8000/concepts/production-network/), then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
 
-Note: The dev-ocean repository contains [a guide for running a keeper node in the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/nile-keeper-setup.md) (if you have permission).
+Note: The dev-ocean repository contains [a guide for running a keeper node in the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/keeper-setup.md) (if you have permission).

--- a/content/setup/marketplace.md
+++ b/content/setup/marketplace.md
@@ -59,7 +59,7 @@ When developing your marketplace/publisher app, you will probably use Barge to r
 - Recommended: a [keeper](/concepts/components/#keeper) node with the keeper contracts deployed to it, connected to an Ocean network
 - Optional: your own [Secret Store](/concepts/components/#secret-store) nodes (for a more advanced setup)
 
-Before running all of that in production with the Ocean Mainnet, you will want to test it with an [Ocean testnet](/concepts/testnets/).
+Before running all of that in production with the [Ocean Production Network](/concepts/production-network/), you will want to test it with an [Ocean testnet](/concepts/testnets/).
 
 Of course, there are many other things that must be handled in production:
 

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -76,35 +76,3 @@ curl --data '{"address":"<YOUR ADDRESS>"}' -H "Content-Type: application/json" -
 ## Get Ocean Tokens
 
 See the page about [Ocean Tokens](/concepts/ocean-tokens/).
-
-### Get Testnet Ocean Tokens
-
-All Squid libraries have methods to request Ocean Tokens. They work by calling the "Dispenser" keeper contract, a contract which is only deployed to testnets. Therefore they will only work in testnets. They're documented in the following places:
-
-- The squid-js docs for:
-  - [OceanAccounts.requestTokens()](/references/squid-js/#OceanAccounts-requestTokens)
-  - [Account.requestTokens()](/references/squid-js/#Account-requestTokens)
-- The squid-py docs for:
-  - [the `squid_py.ocean.ocean_tokens` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_tokens.html): see the `request()` method.
-  - [the `squid_py.ocean.ocean_accounts` module](https://squid-py.readthedocs.io/en/develop/api/squid_py.ocean.ocean_accounts.html): see the `request_tokens()` method.
-- [The squid-java docs](https://www.javadoc.io/doc/com.oceanprotocol/squid/): click "All Classes" then "AccountsManager" then scroll to the bottom of the Class AccountsManager page where you'll find the `requestTokens()` method.
-
-The [Example Code page](/tutorials/example-code/) has links to example Squid code (in all of the languages), including examples of using the above methods.
-
-### Get Mainnet Ocean Tokens
-
-There were several ways to acquire some of the Mainnet Ocean Tokens in the initial circulating supply, including:
-
-- participation in the seed round
-- participation in the pre-sale
-- participation in the token sale
-- participation in the initial exchange offering
-- completion of a [bounty](/concepts/bounties/)
-
-After [the initial exchange offering on Bittrex International](https://blog.oceanprotocol.com/initial-exchange-offering-of-ocean-protocol-on-bittrex-international-a454688f466a), Mainnet Ocean Tokens became available in the Ethereum Mainnet (_not_ the Ocean Mainnet; there was no Ocean Mainnet at the time).
-
-As of 7 May 2019, there was one exchange in the official list of exchanges listing Mainnet Ocean Tokens (in the Ethereum Mainnet): **Bittrex International**.
-
-In the future, the Ocean Mainnet will be launched and later it will become possible to move Ocean Tokens from the Ethereum Mainnet to the Ocean Mainnet.
-
-In the future, it will become possible to earn Mainnet Ocean Tokens as network rewards and in other ways. The [Ocean Protocol Technical Whitepaper](https://oceanprotocol.com/tech-whitepaper.pdf) gives more details.

--- a/data/sidebars/concepts.yml
+++ b/data/sidebars/concepts.yml
@@ -10,6 +10,8 @@
       link: /concepts/tools/
     - title: Testnets
       link: /concepts/testnets/
+    - title: Production Network
+      link: /concepts/production-network/
     - title: Ocean Tokens
       link: /concepts/ocean-tokens/
     - title: Wallet Basics


### PR DESCRIPTION
This pull request updates the terminology used for the "Ocean Production Network" (in the docs website). Before I was calling it the "Ocean Mainnet".

- Added a new page (under "Concepts") about the Ocean Production Network. It lists some other terminology that is sometimes used for that network.
- Also made some updates to the subsection about "mainnet" Ocean Tokens (including renaming that subsection).
- Also fixed a link to https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/keeper-setup.md