### PR TITLE
Update the Tools and Example-Code Pages

### DIFF
--- a/content/concepts/tools.md
+++ b/content/concepts/tools.md
@@ -5,11 +5,9 @@ description: Some tools that can be useful when working with Ocean Protocol.
 
 ## Plecos
 
-Plecos is a Python tool to check metadata (a JSON file) to see if it conforms to the [OEP-8 schema](https://github.com/oceanprotocol/OEPs/tree/master/8). It wraps the [jsonschema](https://github.com/Julian/jsonschema) validator. It can be found in [the Plecos repository on GitHub](https://github.com/oceanprotocol/plecos) and as [a Python package in PyPI](https://pypi.org/project/plecos/).
+Plecos is a Python tool to check metadata (a JSON file) to see if it conforms to the [OEP-8 schema](https://github.com/oceanprotocol/OEPs/tree/master/8). It wraps the [jsonschema](https://github.com/Julian/jsonschema) validator. Aquarius uses Plecos for checking metadata and other Ocean Protocol software will probably use it in the future.
 
-<repo name="Plecos"></repo>
-
-Note: Aquarius uses Plecos for checking metadata and other Ocean Protocol software will probably use it in the future.
+<repo name="plecos"></repo>
 
 ## Faucet Server
 
@@ -19,6 +17,15 @@ The [Ocean Protocol Faucet Server](https://github.com/oceanprotocol/faucet) is a
 
 ## Submarine Blockchain Explorer
 
-Submarine is based on [BlockScout](https://github.com/poanetwork/blockscout) (by [POA](https://poa.network/)), an open source blockchain explorer for Ethereum networks.
-
+Submarine is based on [BlockScout](https://github.com/poanetwork/blockscout) (by [POA](https://poa.network/)), an open source blockchain explorer for EVM-based blockchain networks.
 There is an [Ocean Protocol fork of BlockScout](https://github.com/oceanprotocol/blockscout). An instance is deployed in the Nile Testnet at [https://submarine.dev-ocean.com/](https://submarine.dev-ocean.com/).
+
+<repo name="blockscout"></repo>
+
+## Command-Line Interfaces
+
+There are a few Ocean Protocol command-line interfaces (CLIs). All of them were under development at the time of writing, so you may have issues with using them.
+
+- [tuna](https://github.com/oceanprotocol/tuna) can help you use squid-py, squid-js or squid-java from the command line
+- [ocean-cli](https://github.com/bigchaindb-gmbh/ocean-cli) was built using squid-java
+- [ocean-cli-py](https://github.com/bigchaindb-gmbh/ocean-cli-py) was built using squid-py

--- a/content/tutorials/example-code.md
+++ b/content/tutorials/example-code.md
@@ -8,6 +8,7 @@ description: Examples of code using the Squid libraries.
 - [The squid-py tutorials in Jupyter notebooks](/tutorials/jupyter-notebooks/)
 - [The squid_py/examples/ directory of the squid-py repository](https://github.com/oceanprotocol/squid-py/tree/develop/examples)
 - [The squid-py tests](https://github.com/oceanprotocol/squid-py/tree/develop/tests)
+- [ocean-cli-py](https://github.com/bigchaindb-gmbh/ocean-cli-py) is an Ocean Protocol command-line interface built using squid-py
 
 ## squid-js Examples
 
@@ -22,3 +23,4 @@ description: Examples of code using the Squid libraries.
 
 - [The squid-java README.md file](https://github.com/oceanprotocol/squid-java/blob/develop/README.md)
 - [The squid-java tests](https://github.com/oceanprotocol/squid-java/tree/develop/src/test)
+- [ocean-cli](https://github.com/bigchaindb-gmbh/ocean-cli) is an Ocean Protocol command-line interface built using squid-java

--- a/data/repositories.yml
+++ b/data/repositories.yml
@@ -31,7 +31,10 @@
       links:
         - name: API reference
           url: https://www.javadoc.io/doc/com.oceanprotocol/squid/
-    - name: Plecos
+    - name: plecos
+    - name: faucet
+    - name: blockscout
+    - name: tuna
 
 - group: OceanDB
   items:

--- a/src/components/Repositories/Repository.jsx
+++ b/src/components/Repositories/Repository.jsx
@@ -12,7 +12,7 @@ const queryGithub = graphql`
     query GitHubReposInfo {
         github {
             organization(login: "oceanprotocol") {
-                repositories(first: 100, privacy: PUBLIC, isFork: false) {
+                repositories(first: 100, privacy: PUBLIC) {
                     edges {
                         node {
                             name


### PR DESCRIPTION
Note: I added `<repo name="blockscout"></repo>` in the Tools page but it doesn't render and I'm not sure why. Maybe it's because that repo is a fork? Anyway, it's not super-important. There _is_ a hyperlink to its repo.

![Screenshot from 2019-06-06 14-18-48](https://user-images.githubusercontent.com/1210951/59032225-0b59ff80-8866-11e9-8a1b-cbc7c2d73032.png)
