### PR TITLE
split up repos list, add Osmosis, add parity fork

### DIFF
--- a/content/concepts/components.md
+++ b/content/concepts/components.md
@@ -21,6 +21,8 @@ See also: [Run a Keeper](/setup/keeper/)
 
 A [Parity Secret Store](https://wiki.parity.io/Secret-Store): software for distributed key pair generation, distributed key storage, and threshold retrieval. It's used to store [asset](/concepts/terminology/#asset-or-data-asset) access-control keys.
 
+<repo name="parity-ethereum"></repo>
+
 There are several clients for integrating the Parity Secret Store into Ocean:
 
 <repo name="secret-store-client-js"></repo>

--- a/data/repositories.yml
+++ b/data/repositories.yml
@@ -31,20 +31,30 @@
       links:
         - name: API reference
           url: https://www.javadoc.io/doc/com.oceanprotocol/squid/
+
+- group: Tools
+  items:
     - name: plecos
     - name: faucet
     - name: blockscout
     - name: tuna
 
-- group: OceanDB
+- group: OceanDB Drivers
   items:
     - name: oceandb-mongodb-driver
     - name: oceandb-bigchaindb-driver
     - name: oceandb-elasticsearch-driver
     - name: oceandb-driver-interface
 
+- group: Osmosis Drivers
+  items:
+    - name: osmosis-azure-driver
+    - name: osmosis-aws-driver
+    - name: osmosis-on-premise-driver
+
 - group: Parity Secret Store
   items:
+    - name: parity-ethereum
     - name: secret-store-client-js
       links:
         - name: Architecture


### PR DESCRIPTION
New sections for front-page repo list:
- Tools
- Osmosis Drivers

This reflects more the structure of the _Software Components_ doc.

Also added `parity-ethereum` fork cause I think this repo is what we're using to run our secret store.

Resulting in:

<img width="1310" alt="Screen Shot 2019-06-07 at 14 33 57" src="https://user-images.githubusercontent.com/90316/59104442-e29f3c00-8931-11e9-93b4-33f0a43a3033.png">
