### PR TITLE
Updated language

### DIFF
--- a/content/concepts/components.md
+++ b/content/concepts/components.md
@@ -1,13 +1,13 @@
 ---
 title: Software Components
-description: The Ocean Protocol network is brought to life by many interacting symbiotic software components.
+description: Every Ocean network is brought to life by many interacting symbiotic software components.
 ---
 
 Before reading this page, you should understand some [Ocean-specific terminology](/concepts/terminology/).
 
 ## Keeper
 
-A computer running a blockchain client
+A computer running an EVM-compatible blockchain client
 (such as [Parity Ethereum](https://www.parity.io/ethereum/))
 where the associated blockchain network is running the Ocean Protocol
 [keeper-contracts](https://github.com/oceanprotocol/keeper-contracts)

--- a/content/concepts/contributing.md
+++ b/content/concepts/contributing.md
@@ -29,7 +29,7 @@ To suggest a change to the Ocean Protocol itself (which is actually a set of pro
 
 You could write articles or blog posts related to Ocean Protocol. Possible topics include:
 
-- a story about how you used Ocean Protocol or the Ocean network
+- a story about how you used Ocean Protocol or an Ocean network
 - news from a recent event
 - tutorials for beginners
 - a deep dive into some specific aspect of Ocean Protocol

--- a/content/concepts/ocean-tokens.md
+++ b/content/concepts/ocean-tokens.md
@@ -67,8 +67,6 @@ At the time of writing, you could use Ethereum Mainnet Ocean Tokens to do variou
 - buy other cryptocurrencies. See the next subsection for more details.
 - stake in [dxDAO](https://dxdao.daostack.io/).
 
-Moreover, in the near future, there are plans to make it possible to use Ethereum Mainnet Ocean Tokens for Ocean Protocol tasks in the Ethereum Mainnet. That includes asset and service acquisition, via Ocean Protocol marketplaces attached to the Ethereum Mainnet.
-
 ### How to Buy or Sell Ethereum Mainnet Ocean Tokens
 
 You can buy or sell Ethereum Mainnet Ocean Tokens via any exchange that lists them. See the official list of exchanges below.
@@ -92,7 +90,6 @@ At some point after the Ocean Production Network is launched, it will become pos
 ## Further Reading about Ocean Tokens
 
 - [Teach Your Wallet to Track Ocean Tokens](/tutorials/wallets-and-ocean-tokens/)
-- [Get Ether and Ocean Tokens](/tutorials/get-ether-and-ocean-tokens/)
 - “[Ocean Tokenomics](https://blog.oceanprotocol.com/ocean-tokenomics-d34f28c480a8)”
 - “[Ocean Tokenomics II](https://blog.oceanprotocol.com/https-blog-oceanprotocol-com-ocean-tokenomics-ii-faf05854314b)”
 - [Ocean Protocol Technical Whitepaper](https://oceanprotocol.com/tech-whitepaper.pdf)

--- a/content/concepts/production-network.md
+++ b/content/concepts/production-network.md
@@ -5,7 +5,7 @@ description: An introduction to the Ocean Production Network.
 
 **At the time of writing, there was no live, running, publicly-available Ocean Production Network.**
 
-Ocean Protocol makes use of several EVM networks, including:
+Ocean Protocol makes use of several EVM-compatible networks, including:
 
 - the Ethereum Mainnet (also called the Main Ethereum Network),
 - various [testnets](/concepts/testnets/), and
@@ -21,4 +21,4 @@ The Ocean Production Network will be an EVM network of nodes ("keepers") running
 
 "Network" is sometimes shortened to just "Net."
 
-[Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet (and still were, at the time of writing). For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).
+[Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM-compatible network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet (and still were, at the time of writing). For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).

--- a/content/concepts/resources.md
+++ b/content/concepts/resources.md
@@ -13,7 +13,7 @@ All papers can be retrieved from the [Papers section](https://oceanprotocol.com/
 
 ## Roadmap
 
-[Ocean Protocol roadmap](https://oceanprotocol.com/protocol/#roadmap) outlining our plans and achievements in creating the Ocean Protocol network and building a community and ecosystem around it.
+[Ocean Protocol roadmap](https://oceanprotocol.com/protocol/#roadmap) outlining our plans and achievements in creating Ocean Protocol and building a community and ecosystem around it.
 
 ## Blog
 

--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -5,7 +5,7 @@ description: Terminology specific to Ocean Protocol.
 
 ## Ocean Network
 
-Any EVM-compatible network where all<super>*</super> the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks. Examples include the [testnets](/concepts/testnets/) and [the Ocean Production Network](/concepts/production-network/).
+Any EVM-compatible network where all<super>\*</super> the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks. Examples include the [testnets](/concepts/testnets/) and [the Ocean Production Network](/concepts/production-network/).
 
 Note: Some old documentation refers to "the Ocean Network" or "the Ocean Protocol Network." You will have to guess which network was meant, based on the context.
 

--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -3,9 +3,17 @@ title: Terminology
 description: Terminology specific to Ocean Protocol.
 ---
 
+## Ocean Network
+
+Any EVM-compatible network where all<super>*</super> the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks. Examples include the [testnets](/concepts/testnets/) and [the Ocean Production Network](/concepts/production-network/).
+
+Note: Some old documentation refers to "the Ocean Network" or "the Ocean Protocol Network." You will have to guess which network was meant, based on the context.
+
+\* The "Dispenser" smart contract should only be deployed to testnets.
+
 ## Asset or Data Asset
 
-Anything that can be registered with and made available via the Ocean Network. Examples include data sets, trained model parameters, pipelines, and data-cleaning services.
+Anything that can be registered with and made available via an Ocean Network. Examples include data sets, trained model parameters, pipelines, and data-cleaning services.
 
 ## Data Owner or Data Service Provider
 
@@ -25,7 +33,7 @@ Someone who wants assets. An example is a data scientist working at an economic 
 
 ## Marketplace
 
-A service where publishers can list what assets they have, and consumers can see what's available then buy it (or get it for free). Every marketplace has a database where they store metadata about the assets they know about (but not the assets themselves). The Ocean network supports many marketplaces.
+A service where publishers can list what assets they have, and consumers can see what's available then buy it (or get it for free). Every marketplace has a database where they store metadata about the assets they know about (but not the assets themselves). An Ocean network can support many marketplaces.
 
 ## Verifier
 
@@ -35,7 +43,7 @@ A person or a software service that checks some steps in transactions. For examp
 
 A contract-like agreement between a publisher, a consumer, and a verifier, specifying what assets are to be delivered (from publisher to consumer), the conditions that must be met, and the rewards for fulfilling the conditions.
 
-We published an [Ocean Protocol blog post that explains SEAs in more detail](https://blog.oceanprotocol.com/exploring-the-sea-service-execution-agreements-65f7523d85e2). [OEP-11](https://github.com/oceanprotocol/OEPs/tree/master/11) is a technical specification of how SEAs mediate access control.
+We published an [Ocean Protocol blog post that explains SEAs in more detail](https://blog.oceanprotocol.com/exploring-the-sea-service-execution-agreements-65f7523d85e2).
 
 ## More Terminology
 

--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -5,11 +5,9 @@ description: Terminology specific to Ocean Protocol.
 
 ## Ocean Network
 
-Any EVM-compatible network where all<super>\*</super> the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks. Examples include the [testnets](/concepts/testnets/) and [the Ocean Production Network](/concepts/production-network/).
+Any EVM-compatible network where all[^1] the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks. Examples include the [testnets](/concepts/testnets/) and [the Ocean Production Network](/concepts/production-network/).
 
 Note: Some old documentation refers to "the Ocean Network" or "the Ocean Protocol Network." You will have to guess which network was meant, based on the context.
-
-\* The "Dispenser" smart contract should only be deployed to testnets.
 
 ## Asset or Data Asset
 
@@ -49,3 +47,5 @@ We published an [Ocean Protocol blog post that explains SEAs in more detail](htt
 
 - See [the page about Ocean's Software Components](/concepts/components/).
 - See [the page about wallets (and other Ethereum terminology)](/concepts/wallets/).
+
+[^1]: The "Dispenser" smart contract should only be deployed to testnets.

--- a/src/components/Repositories/index.jsx
+++ b/src/components/Repositories/index.jsx
@@ -46,7 +46,7 @@ const Repositories = () => (
                                     software components
                                 </Link>{' '}
                                 document for an introduction to the components
-                                creating the Ocean network.
+                                found in a typical Ocean network.
                             </strong>
                         </p>
                     </header>


### PR DESCRIPTION
- Changed all instances of "the Ocean network" or "the Ocean Protocol network" to "an Ocean network" or similar.
- Added a section to the **Terminology** page to define what is meant by (an) Ocean Network.
- Standardized on "EVM-compatible network".
- OEP-11 doesn't really delve into how SEAs work so I removed the sentence suggesting that it does.
- Various other minor edits. ◔ ⌣ ◔