### PR TITLE
Updates re/ Elasticsearch, MongoDB and BigchainDB

### DIFF
--- a/content/concepts/components.md
+++ b/content/concepts/components.md
@@ -37,11 +37,12 @@ Marketplaces run Aquarius to store and manage metadata about the [assets](/conce
 
 ### OceanDB Drivers
 
-Aquarius supports several options for the off-chain database (OceanDB), including MongoDB, Elasticsearch and BigchainDB. One can add support for another off-chain database by creating a new driver similar to the existing OceanDB drivers.
+Aquarius supports several options for the off-chain database (OceanDB), including Elasticsearch and MongoDB. One can add support for another off-chain database by creating a new driver similar to the existing OceanDB drivers.
 
-<repo name="oceandb-mongodb-driver"></repo>
-<repo name="oceandb-bigchaindb-driver"></repo>
 <repo name="oceandb-elasticsearch-driver"></repo>
+<repo name="oceandb-mongodb-driver"></repo>
+
+Note: There is also a BigchainDB driver but it hasn't been maintained.
 
 ## Brizo
 

--- a/content/concepts/contributing.md
+++ b/content/concepts/contributing.md
@@ -51,7 +51,7 @@ See the page about [bounties](/concepts/bounties/).
 
 ## Develop a Service Integration Driver or Plugin
 
-- Aquarius currently supports storing metadata in MongoDB, Elasticsearch or BigchainDB. Each option is supported by its own "OceanDB driver." You could write a new OceanDB driver to support another database. See [the existing OceanDB repositories for examples](https://github.com/oceanprotocol?utf8=%E2%9C%93&q=oceandb&type=&language=).
+- Aquarius currently supports storing metadata in Elasticsearch or MongoDB. Each option is supported by its own "OceanDB driver." You could write a new OceanDB driver to support another database. See [the existing OceanDB repositories for examples](https://github.com/oceanprotocol?utf8=%E2%9C%93&q=oceandb&type=&language=).
 - Brizo currently supports storing data sets in Azure Storage, Amazon S3 or on-premise. Each option is supported by its own "Osmosis driver." You could write a new Osmosis driver to support another storage provider. See [the existing Osmosis repositories for examples](https://github.com/oceanprotocol?utf8=%E2%9C%93&q=osmosis&type=&language=).
 - [OEP-11 lists the supported encryption and decryption options](https://github.com/oceanprotocol/OEPs/tree/master/11#encryption-and-decryption) (for encrypting URLs before putting them in the metadata, not data sets themselves). You could add support for another option.
 - Other kinds of services could also be integrated. If you need help or advice, then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.

--- a/content/setup/marketplace.md
+++ b/content/setup/marketplace.md
@@ -54,7 +54,7 @@ When developing your marketplace/publisher app, you will probably use Barge to r
 
 - Your marketplace/publisher app
 - [Aquarius](/concepts/components/#aquarius)
-- A database to go with Aquarius, e.g. MongoDB or Elasticsearch
+- A database to go with Aquarius, e.g. Elasticsearch or MongoDB
 - [Brizo](/concepts/components/#brizo)
 - Recommended: a [keeper](/concepts/components/#keeper) node with the keeper contracts deployed to it, connected to an Ocean network
 - Optional: your own [Secret Store](/concepts/components/#secret-store) nodes (for a more advanced setup)

--- a/data/repositories.yml
+++ b/data/repositories.yml
@@ -42,7 +42,6 @@
 - group: OceanDB Drivers
   items:
     - name: oceandb-mongodb-driver
-    - name: oceandb-bigchaindb-driver
     - name: oceandb-elasticsearch-driver
     - name: oceandb-driver-interface
 

--- a/data/repositories.yml
+++ b/data/repositories.yml
@@ -41,8 +41,8 @@
 
 - group: OceanDB Drivers
   items:
-    - name: oceandb-mongodb-driver
     - name: oceandb-elasticsearch-driver
+    - name: oceandb-mongodb-driver
     - name: oceandb-driver-interface
 
 - group: Osmosis Drivers


### PR DESCRIPTION
- Elasticsearch is becoming the default and recommended backend for Aquarius, so change the emphasis to mention it before MongoDB.
- BigchainDB isn't really supported anymore, so I removed all mention of it.