### PR TITLE
Update the URLs of some components attached to the Nile Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ The sidebar for those generated reference pages will automatically switch to inc
 
 Reference pages based on Swagger specs are sourced from remotely hosted Swagger specs:
 
-- [`https://nginx-aquarius.dev-ocean.com/spec`](https://nginx-aquarius.dev-ocean.com/spec)
-- [`https://nginx-brizo.dev-ocean.com/spec`](https://nginx-brizo.dev-ocean.com/spec)
+- [`https://aquarius.nile.dev-ocean.com/spec`](https://aquarius.nile.dev-ocean.com/spec)
+- [`https://brizo.nile.dev-ocean.com/spec`](https://brizo.nile.dev-ocean.com/spec)
 
 They are fetched and updated automatically upon every site build. For more information about stylistic issues, take a look at the section in the test page:
 

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -42,14 +42,14 @@ There is a Nile blockchain explorer at [https://submarine.dev-ocean.com/](https:
 
 There are several Ocean Protocol software components that are live, connected to the Nile Testnet, and operated by BigchainDB GmbH:
 
-- Secret Store at [https://secret-store.dev-ocean.com](https://secret-store.dev-ocean.com)
-- Aquarius at [https://nginx-aquarius.dev-ocean.com](https://nginx-aquarius.dev-ocean.com)
-- Brizo at [https://nginx-brizo.dev-ocean.com](https://nginx-brizo.dev-ocean.com)
+- Secret Store at [https://secret-store.nile.dev-ocean.com](https://secret-store.nile.dev-ocean.com)
+- Aquarius at [https://aquarius.nile.dev-ocean.com/](https://aquarius.nile.dev-ocean.com/)
+- Brizo at [https://brizo.nile.dev-ocean.com/](https://brizo.nile.dev-ocean.com/)
 - Jupyter Hub at [https://mantaray.dev-ocean.com](https://mantaray.dev-ocean.com)
-- Commons Marketplace at [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)
+- Commons Marketplace at [https://commons.nile.dev-ocean.com](https://commons.nile.dev-ocean.com)
 - Aquarius for Commons Marketplace at [https://aquarius.marketplace.dev-ocean.com](https://aquarius.marketplace.dev-ocean.com)
 - Brizo for Commons Marketplace at [https://brizo.marketplace.dev-ocean.com](https://brizo.marketplace.dev-ocean.com)
-- Faucet Server at [faucet.nile.dev-ocean.com](https://faucet.nile.dev-ocean.com)
+- Faucet Server at [https://faucet.nile.dev-ocean.com](https://faucet.nile.dev-ocean.com)
 
 > Internal note: The private "atlantic" repo documents the internal details of the Nile Testnet in `networks/nile/README.md`.
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -251,7 +251,7 @@ const createTypeDocPage = async (createPage, name, downloadUrl) => {
 // https://github.com/swagger-api/swagger-js
 const fetchSwaggerSpec = async name => {
     try {
-        const client = await Swagger(`https://nginx-${name}.dev-ocean.com/spec`)
+        const client = await Swagger(`https://${name}.nile.dev-ocean.com/spec`)
         return client.spec // The resolved spec
 
         // client.originalSpec // In case you need it


### PR DESCRIPTION
I asked Javi about these URLs this morning, so they are the latest. Some of them aren't working yet because he's still updating things.

I also added the `https://` to the start of the Faucet Server's displayed URL, to be consistent with all the other ones.

We might want to wait for them to be working before merging this pull request. On the other hand, some of the URLs listed on the currently-live docs website are now broken.