### PR TITLE
[WIP] Document some Pacific Network details

### DIFF
--- a/content/concepts/pacific-network.md
+++ b/content/concepts/pacific-network.md
@@ -49,12 +49,9 @@ There is a Pacific blockchain explorer at [https://submarine.oceanprotocol.com/]
 There are several Ocean Protocol software components that are live, connected to the Pacific Network, and operated by BigchainDB GmbH:
 
 - Secret Store at [https://secret-store.oceanprotocol.com](https://secret-store.oceanprotocol.com)
-- Aquarius at TODO
-- Brizo at TODO
-- Jupyter Hub at TODO
+- Aquarius at [https://aquarius.commons.oceanprotocol.com](https://aquarius.commons.oceanprotocol.com)
+- Brizo at [https://brizo.commons.oceanprotocol.com](https://brizo.commons.oceanprotocol.com)
 - Commons Marketplace at [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)
-- Aquarius for Commons Marketplace at [https://aquarius.commons.oceanprotocol.com](https://aquarius.commons.oceanprotocol.com)
-- Brizo for Commons Marketplace at [https://brizo.commons.oceanprotocol.com](https://brizo.commons.oceanprotocol.com)
 - Faucet Server at [https://faucet.oceanprotocol.com](https://faucet.oceanprotocol.com)
 - Token Bridge Frontend at [https://bridge.oceanprotocol.com/](https://bridge.oceanprotocol.com/)
 

--- a/content/concepts/pacific-network.md
+++ b/content/concepts/pacific-network.md
@@ -3,15 +3,15 @@ title: The Pacific Network
 description: An introduction to the Pacific Network.
 ---
 
-**At the time of writing, there was no live, running, publicly-available Pacific Network.**
+## Overview
 
 You can use the Ocean Protocol in several EVM-compatible networks, including:
 
 - the Ethereum Mainnet (also called the Main Ethereum Network),
 - various [testnets](/concepts/testnets/), and
-- in the future, the Pacific Network.
+- the Pacific Network.
 
-The Pacific Network will be an EVM-compatible network of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software. Various Ocean Protocol smart contracts ("keeper contracts") will be deployed to it.
+The Pacific Network is an EVM-compatible network of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software. Various Ocean Protocol smart contracts ("keeper contracts") are deployed to it.
 
 The Pacific Network is (or was) also known by other names, including:
 
@@ -22,12 +22,44 @@ The Pacific Network is (or was) also known by other names, including:
 
 "Network" is sometimes shortened to just "Net."
 
-Initially, all the nodes in the Pacific Network will be operated solely by BigchainDB GmbH (i.e. one company), but the goal is for the nodes to be operated by many independent operators in the future.
+Initially, all the nodes in the Pacific Network were operated solely by BigchainDB GmbH (i.e. one company), but the goal was for the nodes to be operated by many independent operators in the future.
 
-Initially, the Pacific Network will not be production-ready, that is, it will not be suitable for production use cases.
 We expect vulnerabilities to be discovered and will conduct security audits over time, but the Ocean Protocol smart contracts will be in the wild for all intents and purposes.
 Over time, the Pacific Network will be upgraded and improved.
 There is no intent to shut it down.
-Eventually, the goal is for it to become production-ready.
+Eventually, the goal is for it to be used in production by many projects.
 
-[Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM-compatible network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet. There will be a token bridge between the Ethereum Mainnet and the Pacific Network, allowing anyone with Ocean Tokens to move them from the Ethereum Mainnet to the Pacific Network. However, please be aware that doing so would put those Ocean Tokens at risk. For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).
+[Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM-compatible network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet. There is a token bridge between the Ethereum Mainnet and the Pacific Network, allowing anyone with Ocean Tokens to move them from the Ethereum Mainnet to the Pacific Network. However, please be aware that doing so would put those Ocean Tokens at risk. For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).
+
+## Connect to the Pacific Network
+
+See the [tutorial page about connecting to Ocean-related networks](/tutorials/connect-to-networks/#connect-to-the-pacific-network).
+
+## Pacific Blockchain Explorers
+
+There is a Pacific blockchain explorer at [https://submarine.oceanprotocol.com/](https://submarine.oceanprotocol.com/). You can use it to check the status of a transaction, the balance of an account, and more. It uses the following symbols for Pacific Ether and Pacific Ocean Tokens:
+
+| Cryptocurrency       | Symbol used      |
+| -------------------- | ---------------- |
+| Pacific Ether        | POA              |
+| Pacific Ocean Tokens | OCEAN or SBT-OCN |
+
+## Ocean Components Connected to Pacific
+
+There are several Ocean Protocol software components that are live, connected to the Pacific Network, and operated by BigchainDB GmbH:
+
+- Secret Store at [https://secret-store.oceanprotocol.com](https://secret-store.oceanprotocol.com)
+- Aquarius at TODO
+- Brizo at TODO
+- Jupyter Hub at TODO
+- Commons Marketplace at [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)
+- Aquarius for Commons Marketplace at [https://aquarius.commons.oceanprotocol.com](https://aquarius.commons.oceanprotocol.com)
+- Brizo for Commons Marketplace at [https://brizo.commons.oceanprotocol.com](https://brizo.commons.oceanprotocol.com)
+- Faucet Server at [https://faucet.oceanprotocol.com](https://faucet.oceanprotocol.com)
+- Token Bridge Frontend at [https://bridge.oceanprotocol.com/](https://bridge.oceanprotocol.com/)
+
+> Internal note: The private "atlantic" repo documents the internal details of the Pacific Network in `networks/pacific/deployment.md`.
+
+## Using Barge with Pacific
+
+If you run [Barge](https://github.com/oceanprotocol/barge) with the `--local-pacific-node` option, then Barge will run a Pacific node on your local machine (along with everything else Barge runs). There might be many blocks in the Pacific Network's blockchain, so it might take a long time for your local Pacific node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Pacific node won't be able to do certain things.**

--- a/content/tutorials/connect-to-networks.md
+++ b/content/tutorials/connect-to-networks.md
@@ -27,3 +27,20 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local N
 ## Connect to a Local Spree Testnet or Ganache-Based Testnet
 
 When using [Barge](https://github.com/oceanprotocol/barge) to run a purely-local testnet (Spree or Ganache-based), you can connect to a local node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
+
+## Connect to the Pacific Network
+
+Here are the parameters you might need to connect to the [Pacific Network](/concepts/pacific-network/):
+
+| Parameter          | Value                                                   |
+| ------------------ | ------------------------------------------------------- |
+| RPC URL (required) | [https://pacific.oceanprotocol.com][rpc-url]            |
+| ChainID            | `TODO` (decimal for MetaMask) or `0xTODO` (hexadecimal) |
+| Symbol             | Whatever you like, e.g. `PACIFIC ETH`                   |
+| Nickname           | Whatever you like, e.g. `Pacific`                       |
+
+In MetaMask, click on the network name then click on `Custom RPC` in the drop-down list. Scroll down to the `New Network` section. Enter the above RPC URL. You don't need to add a port number to the end of the RPC URL. Enter the ChainID, Symbol and Nickname if you like. See the [MetaMask docs about how it uses the ChainID](https://metamask.github.io/metamask-docs/Main_Concepts/Sending_Transactions).
+
+If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Pacific node, you can connect to that local Pacific node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask). You can configure that local Pacific node by editing the files in the `barge/networks/pacific/config/` directory.
+
+[rpc-url]: https://pacific.oceanprotocol.com

--- a/content/tutorials/connect-to-networks.md
+++ b/content/tutorials/connect-to-networks.md
@@ -35,7 +35,7 @@ Here are the parameters you might need to connect to the [Pacific Network](/conc
 | Parameter          | Value                                                   |
 | ------------------ | ------------------------------------------------------- |
 | RPC URL (required) | [https://pacific.oceanprotocol.com][rpc-url]            |
-| ChainID            | `TODO` (decimal for MetaMask) or `0xTODO` (hexadecimal) |
+| ChainID            | `846353` (decimal for MetaMask) or `0xcea11` (hexadecimal) |
 | Symbol             | Whatever you like, e.g. `PACIFIC ETH`                   |
 | Nickname           | Whatever you like, e.g. `Pacific`                       |
 

--- a/content/tutorials/wallets-and-ocean-tokens.md
+++ b/content/tutorials/wallets-and-ocean-tokens.md
@@ -7,6 +7,8 @@ If you don't see any Ocean Tokens in your crypto wallet software (e.g. MetaMask 
 
 ## Step 1: Determine the Ocean Token Contract Address in the Network You're Using
 
+If you know the URL of a Brizo instance attached to the network you're using, then just go to that URL in your web browser and get the value of `contracts.OceanToken`.
+
 ### Kovan or Nile Testnet
 
 | Testnet | Ocean Token Contract Address                 |
@@ -40,6 +42,12 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local S
 The Ocean Token contract address in the Ethereum Mainnet is:
 
 `0x985dd3D42De1e256d09e1c10F112bCCB8015AD41`
+
+### Pacific Network
+
+The Ocean Token contract address in the [Pacific Network](/concepts/pacific-network/) is:
+
+`0x012578f9381e876A9E2a9111Dfd436FF91A451ae`
 
 ## Step 2: Teach Your Wallet Software about Ocean Tokens
 


### PR DESCRIPTION
This pull request should not be merged until 1) the TODO stuff (listed below) is done and 2) the Pacific Network has officially been announced to the world as being live and ready-to-use.

It documents some details of the Pacific Network such as:

- how to connect to it (e.g. the RPC URL)
- URLs of Ocean components connected to Pacific
- the OceanToken contract address in Pacific

## TODO stuff

There are still some things to do before this pull request can be merged. Search for "TODO" to find them:

- The ChainID (of the Pacific Network's blockchain)
- The Aquarius URL (but not the Commons Aquarius URL, which is already given)
- The Brizo URL (but not the Commons Brizo URL, which is already given)
- The JupyterHub URL, if there is one
