### PR TITLE
More Pacific changes

### DIFF
--- a/content/concepts/components.md
+++ b/content/concepts/components.md
@@ -78,7 +78,7 @@ An example marketplace/publisher front-end for developers to explore, download, 
 
 ## Commons Marketplace
 
-An online example marketplace/publisher for consumers to explore, download, and publish open data sets in the [Nile Testnet](/concepts/testnets/#the-nile-testnet). Implemented using [React](https://reactjs.org/) and [squid-js](https://github.com/oceanprotocol/squid-js).
+An online example marketplace/publisher for consumers to explore, download, and publish open data sets in the [Pacific Network](/concepts/pacific-network/). Implemented using [React](https://reactjs.org/) and [squid-js](https://github.com/oceanprotocol/squid-js).
 
 For more information, see [the blog post about Commons Marketplace](https://blog.oceanprotocol.com/the-commons-data-marketplace-c57a44288314).
 

--- a/content/concepts/ocean-tokens.md
+++ b/content/concepts/ocean-tokens.md
@@ -17,7 +17,7 @@ description: The technical basics of Ocean Tokens.
 
 ## Testnet Ocean Tokens
 
-There are Ocean Tokens in several testnets, including the Kovan testnet and Nile testnet. They are just testnet Ocean Tokens (i.e. for testing purposes only) and they aren't interchangeable with Ethereum Mainnet Ocean Tokens. For more details, see the the [page about Testnets](/concepts/testnets/) and the [tutorials](/tutorials/introduction/).
+There are Ocean Tokens in several testnets, including the Nile testnet. They are just testnet Ocean Tokens (i.e. for testing purposes only) and they aren't interchangeable with Ethereum Mainnet Ocean Tokens. For more details, see the the [page about Testnets](/concepts/testnets/) and the [tutorials](/tutorials/introduction/).
 
 ### Testnet Ocean Token Utility
 

--- a/content/concepts/pacific-network.md
+++ b/content/concepts/pacific-network.md
@@ -48,12 +48,16 @@ There is a Pacific blockchain explorer at [https://submarine.oceanprotocol.com/]
 
 There are several Ocean Protocol software components that are live, connected to the Pacific Network, and operated by BigchainDB GmbH:
 
-- Secret Store at [https://secret-store.oceanprotocol.com](https://secret-store.oceanprotocol.com)
-- Aquarius at [https://aquarius.commons.oceanprotocol.com](https://aquarius.commons.oceanprotocol.com)
-- Brizo at [https://brizo.commons.oceanprotocol.com](https://brizo.commons.oceanprotocol.com)
-- Commons Marketplace at [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)
-- Faucet Server at [https://faucet.oceanprotocol.com](https://faucet.oceanprotocol.com)
-- Token Bridge Frontend at [https://bridge.oceanprotocol.com/](https://bridge.oceanprotocol.com/)
+| Component              | URL                                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Secret Store           | [https://secret-store.oceanprotocol.com](https://secret-store.oceanprotocol.com)         |
+| Aquarius Test instance | [https://aquarius.test.oceanprotocol.com](https://aquarius.test.oceanprotocol.com)       |
+| Brizo Test instance    | [https://brizo.test.oceanprotocol.com](https://brizo.test.oceanprotocol.com)             |
+| Aquarius for Commons   | [https://aquarius.commons.oceanprotocol.com](https://aquarius.commons.oceanprotocol.com) |
+| Brizo for Commons      | [https://brizo.commons.oceanprotocol.com](https://brizo.commons.oceanprotocol.com)       |
+| Commons Marketplace    | [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)                   |
+| Faucet Server          | [https://faucet.oceanprotocol.com](https://faucet.oceanprotocol.com)                     |
+| Token Bridge Frontend  | [https://bridge.oceanprotocol.com/](https://bridge.oceanprotocol.com/)                   |
 
 > Internal note: The private "atlantic" repo documents the internal details of the Pacific Network in `networks/pacific/deployment.md`.
 

--- a/content/concepts/pacific-network.md
+++ b/content/concepts/pacific-network.md
@@ -1,26 +1,11 @@
 ---
 title: The Pacific Network
-description: An introduction to the Pacific Network.
+description: An introduction to Ocean Protocol's main network, named Pacific.
 ---
 
 ## Overview
 
-You can use the Ocean Protocol in several EVM-compatible networks, including:
-
-- the Ethereum Mainnet (also called the Main Ethereum Network),
-- various [testnets](/concepts/testnets/), and
-- the Pacific Network.
-
-The Pacific Network is an EVM-compatible network of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software. Various Ocean Protocol smart contracts ("keeper contracts") are deployed to it.
-
-The Pacific Network is (or was) also known by other names, including:
-
-- Pacific
-- The Main Ocean Network
-- The Ocean Mainnet
-- The Ocean Live Network
-
-"Network" is sometimes shortened to just "Net."
+The _Pacific Network_[^1] is an EVM-compatible [Proof of Authority (POA) network](https://github.com/poanetwork/wiki/wiki/What-is-POA) of nodes ("keepers") running [Parity Ethereum](https://www.parity.io/ethereum/) software. Various Ocean Protocol smart contracts ("keeper contracts") are deployed to it.
 
 Initially, all the nodes in the Pacific Network were operated solely by BigchainDB GmbH (i.e. one company), but the goal was for the nodes to be operated by many independent operators in the future.
 
@@ -31,13 +16,17 @@ Eventually, the goal is for it to be used in production by many projects.
 
 [Ocean Tokens](/concepts/ocean-tokens/) can, in principle, live in any EVM-compatible network. The ones sold in the Ocean Protocol token sale were in the Ethereum Mainnet. There is a token bridge between the Ethereum Mainnet and the Pacific Network, allowing anyone with Ocean Tokens to move them from the Ethereum Mainnet to the Pacific Network. However, please be aware that doing so would put those Ocean Tokens at risk. For more information, see [the page about Ocean Tokens](/concepts/ocean-tokens/).
 
+[^1]: The Pacific Network is (or was) also known by other names, including _Pacific_, _Main Ocean Network_, _Ocean Mainnet_, _Ocean Live Network_.
+
 ## Connect to the Pacific Network
 
-See the [tutorial page about connecting to Ocean-related networks](/tutorials/connect-to-networks/#connect-to-the-pacific-network).
+See the tutorial page about [connecting to Ocean-related networks](/tutorials/connect-to-networks/#connect-to-the-pacific-network) to connect to Pacific in your browser with MetaMask.
 
 ## Pacific Blockchain Explorers
 
-There is a Pacific blockchain explorer at [https://submarine.oceanprotocol.com/](https://submarine.oceanprotocol.com/). You can use it to check the status of a transaction, the balance of an account, and more. It uses the following symbols for Pacific Ether and Pacific Ocean Tokens:
+There is a Pacific blockchain explorer at [submarine.oceanprotocol.com](https://submarine.oceanprotocol.com/). You can use it to check the status of a transaction, the balance of an account, and more.
+
+It uses the following symbols for Pacific Ether and Pacific Ocean Tokens:
 
 | Cryptocurrency       | Symbol used      |
 | -------------------- | ---------------- |
@@ -48,19 +37,22 @@ There is a Pacific blockchain explorer at [https://submarine.oceanprotocol.com/]
 
 There are several Ocean Protocol software components that are live, connected to the Pacific Network, and operated by BigchainDB GmbH:
 
-| Component              | URL                                                                                      |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| Secret Store           | [https://secret-store.oceanprotocol.com](https://secret-store.oceanprotocol.com)         |
-| Aquarius Test instance | [https://aquarius.test.oceanprotocol.com](https://aquarius.test.oceanprotocol.com)       |
-| Brizo Test instance    | [https://brizo.test.oceanprotocol.com](https://brizo.test.oceanprotocol.com)             |
-| Aquarius for Commons   | [https://aquarius.commons.oceanprotocol.com](https://aquarius.commons.oceanprotocol.com) |
-| Brizo for Commons      | [https://brizo.commons.oceanprotocol.com](https://brizo.commons.oceanprotocol.com)       |
-| Commons Marketplace    | [https://commons.oceanprotocol.com](https://commons.oceanprotocol.com)                   |
-| Faucet Server          | [https://faucet.oceanprotocol.com](https://faucet.oceanprotocol.com)                     |
-| Token Bridge Frontend  | [https://bridge.oceanprotocol.com/](https://bridge.oceanprotocol.com/)                   |
+| Component              | URL                                          |
+| ---------------------- | -------------------------------------------- |
+| Node                   | `https://pacific.oceanprotocol.com`          |
+| Secret Store           | `https://secret-store.oceanprotocol.com`     |
+| Aquarius Test instance | `https://aquarius.test.oceanprotocol.com`    |
+| Brizo Test instance    | `https://brizo.test.oceanprotocol.com`       |
+| Aquarius for Commons   | `https://aquarius.commons.oceanprotocol.com` |
+| Brizo for Commons      | `https://brizo.commons.oceanprotocol.com`    |
+| Commons Marketplace    | `https://commons.oceanprotocol.com`          |
+| Faucet Server          | `https://faucet.oceanprotocol.com`           |
+| Token Bridge Frontend  | `https://bridge.oceanprotocol.com`           |
 
 > Internal note: The private "atlantic" repo documents the internal details of the Pacific Network in `networks/pacific/deployment.md`.
 
 ## Using Barge with Pacific
 
-If you run [Barge](https://github.com/oceanprotocol/barge) with the `--local-pacific-node` option, then Barge will run a Pacific node on your local machine (along with everything else Barge runs). There might be many blocks in the Pacific Network's blockchain, so it might take a long time for your local Pacific node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Pacific node won't be able to do certain things.**
+If you run [Barge](https://github.com/oceanprotocol/barge) with the `--local-pacific-node` option, then Barge will run a Pacific node on your local machine (along with everything else Barge runs).
+
+There might be many blocks in the Pacific Network's blockchain, so it might take a long time for your local Pacific node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Pacific node won't be able to do certain things.**

--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -5,9 +5,11 @@ description: Terminology specific to Ocean Protocol.
 
 ## Ocean Network
 
-Any EVM-compatible network where all[^1] the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks. Examples include the [testnets](/concepts/testnets/) and [the Pacific Network](/concepts/pacific-network/).
+Any EVM-compatible network where all[^1] the Ocean Protocol smart contracts ([keeper contracts](https://github.com/oceanprotocol/keeper-contracts)) are deployed. There can be many Ocean networks and you can use the Ocean Protocol in several EVM-compatible networks, including:
 
-Note: Some old documentation refers to "the Ocean Network" or "the Ocean Protocol Network." You will have to guess which network was meant, based on the context.
+- the Ethereum Mainnet (also called the Main Ethereum Network)
+- the Ocean [Pacific Network](/concepts/pacific-network/)
+- various Ocean [test networks](/concepts/testnets/)
 
 ## Asset or Data Asset
 
@@ -48,4 +50,4 @@ We published an [Ocean Protocol blog post that explains SEAs in more detail](htt
 - See [the page about Ocean's Software Components](/concepts/components/).
 - See [the page about wallets (and other Ethereum terminology)](/concepts/wallets/).
 
-[^1]: The "Dispenser" smart contract should only be deployed to testnets.
+[^1]: The _Dispenser_ smart contract should only be deployed to testnets.

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -3,27 +3,23 @@ title: Testnets
 description: An overview of public test networks that you can test Ocean Protocol applications against.
 ---
 
-You can test an Ocean Protocol application (such as a marketplace) against the test networks (testnets) described below. This page is a brief overview of those testnets. The [tutorials](/tutorials/) cover more details (e.g. how to connect to specific ones).
+This page is a brief overview of available testnets. The [tutorials](/tutorials/) cover more details (e.g. how to connect to specific ones).
 
 ## A Spree Testnet (for Local Development)
 
-_Formerly called Ocean Protocol Testnet v0.1, it was announced as part of the Plankton milestone._
-
-By default, [Barge](https://github.com/oceanprotocol/barge) will deploy a local "Spree Testnet" on your machine: a local testnet not connected to any external public testnet.
+By default, [Barge](https://github.com/oceanprotocol/barge) will deploy a local _Spree Testnet_[^1] on your machine: a local testnet not connected to any external public testnet.
 
 When running a Spree Testnet, you can connect to a node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
 
 Spree Testnet details can be found in the [Barge README.md file](https://github.com/oceanprotocol/barge#spree-network). You can configure the Spree nodes by editing the files in the `barge/networks/spree/` directory.
 
-> Note: Spree testnets are named after the Spree River, the main river flowing through Berlin, Germany, where many Ocean Protocol developers are located.
+> Spree testnets are named after the Spree River, the main river flowing through Berlin, Germany, where many Ocean Protocol developers are located.
 
 ## The Nile Testnet
 
-_Also known as the Nile Beta Network. Formerly called the Ocean POA Testnet._
+In the _Nile Testnet_[^2] all nodes are operated by BigchainDB GmbH.
 
-In the Nile Testnet all nodes are operated by BigchainDB GmbH.
-
-For developers building on Ocean Protocol, we recommend starting with a [Spree Testnet](#a-spree-testnet-for-local-development).
+> For developers building on Ocean Protocol, we recommend starting with a [Spree Testnet](#a-spree-testnet-for-local-development).
 
 ### Connect to the Nile Testnet
 
@@ -42,29 +38,37 @@ There is a Nile blockchain explorer at [https://submarine.dev-ocean.com/](https:
 
 There are several Ocean Protocol software components that are live, connected to the Nile Testnet, and operated by BigchainDB GmbH:
 
-- Secret Store at [https://secret-store.nile.dev-ocean.com](https://secret-store.nile.dev-ocean.com)
-- Aquarius at [https://aquarius.nile.dev-ocean.com/](https://aquarius.nile.dev-ocean.com/)
-- Brizo at [https://brizo.nile.dev-ocean.com/](https://brizo.nile.dev-ocean.com/)
-- Jupyter Hub at [https://mantaray.dev-ocean.com](https://mantaray.dev-ocean.com)
-- Commons Marketplace at [https://commons.nile.dev-ocean.com](https://commons.nile.dev-ocean.com)
-- Aquarius for Commons Marketplace at [https://aquarius.marketplace.dev-ocean.com](https://aquarius.marketplace.dev-ocean.com)
-- Brizo for Commons Marketplace at [https://brizo.marketplace.dev-ocean.com](https://brizo.marketplace.dev-ocean.com)
-- Faucet Server at [https://faucet.nile.dev-ocean.com](https://faucet.nile.dev-ocean.com)
+| Component              | URL                                               |
+| ---------------------- | ------------------------------------------------- |
+| Node                   | `https://nile.dev-ocean.com`                      |
+| Secret Store           | `https://secret-store.nile.dev-ocean.com`         |
+| Aquarius Test instance | `https://aquarius.nile.dev-ocean.com`             |
+| Brizo Test instance    | `https://brizo.nile.dev-ocean.com`                |
+| Aquarius for Commons   | `https://aquarius.marketplace.nile.dev-ocean.com` |
+| Brizo for Commons      | `https://brizo.marketplace.nile.dev-ocean.com`    |
+| Commons Marketplace    | `https://commons.nile.dev-ocean.com`              |
+| Jupyter Hub            | `https://mantaray.dev-ocean.com`                  |
+| Faucet Server          | `https://faucet.nile.dev-ocean.com`               |
 
 > Internal note: The private "atlantic" repo documents the internal details of the Nile Testnet in `networks/nile/README.md`.
 
 ### Using Barge with Nile
 
-If you run [Barge](https://github.com/oceanprotocol/barge) with the `--local-nile-node` option, then Barge will run a Nile node on your local machine (along with everything else Barge runs). There might be many blocks in the Nile Testnet's blockchain, so it might take a long time for your local Nile node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Nile node won't be able to do certain things.**
+If you run [Barge](https://github.com/oceanprotocol/barge) with the `--local-nile-node` option, then Barge will run a Nile node on your local machine (along with everything else Barge runs).
+
+There might be many blocks in the Nile Testnet's blockchain, so it might take a long time for your local Nile node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Nile node won't be able to do certain things.**
 
 ## A Ganache-Based Testnet (for Local Development)
 
 A local testnet similar to Spree but launched by using the `--local-ganache-node` option with Barge.
 
-Note: You shouldn't use a Ganache-Based Testnet unless you know why you're doing so. For example, a Ganache-based testnet can be used to test some smart contracts, but it can't be used with a Secret Store.
+> You shouldn't use a Ganache-Based Testnet unless you know why you're doing so. For example, a Ganache-based testnet can be used to test some smart contracts, but it can't be used with a Secret Store.
 
 ## The Duero Testnet
 
 The Duero Testnet is similar to the Nile Testnet, but it's only for internal use by the Ocean Protocol dev team. They test new things in the Duero Testnet before deploying them in the Nile Testnet (which is for use by anyone). That is, the testing order is Spree (local), Duero (private), Nile (public).
 
 If you need to know something technical about the Duero Testnet, such as the RPC URL, please contact the Ocean Protocol dev team.
+
+[^1]: Formerly called Ocean Protocol Testnet v0.1, it was announced as part of the Plankton milestone.
+[^2]: Also known as the Nile Beta Network. Formerly called the Ocean POA Testnet.

--- a/content/concepts/testnets.md
+++ b/content/concepts/testnets.md
@@ -21,7 +21,7 @@ Spree Testnet details can be found in the [Barge README.md file](https://github.
 
 _Also known as the Nile Beta Network. Formerly called the Ocean POA Testnet._
 
-The Nile Testnet is similar to the Kovan Testnet, except all the nodes are operated by BigchainDB GmbH.
+In the Nile Testnet all nodes are operated by BigchainDB GmbH.
 
 For developers building on Ocean Protocol, we recommend starting with a [Spree Testnet](#a-spree-testnet-for-local-development).
 
@@ -56,29 +56,6 @@ There are several Ocean Protocol software components that are live, connected to
 ### Using Barge with Nile
 
 If you run [Barge](https://github.com/oceanprotocol/barge) with the `--local-nile-node` option, then Barge will run a Nile node on your local machine (along with everything else Barge runs). There might be many blocks in the Nile Testnet's blockchain, so it might take a long time for your local Nile node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Nile node won't be able to do certain things.**
-
-## The Kovan Testnet
-
-The [Kovan Testnet](https://github.com/kovan-testnet/proposal) (or just "Kovan") is a public Ethereum Testnet operated by members of the Ethereum community.
-The Ocean Protocol keeper contracts are deployed to the Kovan Testnet.
-
-For developers building on Ocean Protocol, we recommend starting with a [Spree Testnet](#a-spree-testnet-for-local-development).
-
-### Kovan Blockchain Explorers
-
-There are some Kovan blockchain explorers, e.g. [Etherscan for Kovan](https://kovan.etherscan.io/) and [BlockScout for Kovan](https://blockscout.com/eth/kovan). You can use those to check the status of a transaction, the balance of an account, and more.
-
-### Ocean Components Connected to Kovan
-
-There is a [Secret Store](/concepts/components/#secret-store) connected to the Kovan Testnet for use by Ocean Protocol projects (including your projects). It's operated by BigchainDB GmbH. Its URL is:
-
-[https://secret-store-kovan.dev-ocean.com/](https://secret-store-kovan.dev-ocean.com/)
-
-Aside from the Secret Store, there is no other Ocean Protocol software component (e.g. Aquarius) that is live, connected to the Kovan Testnet, and operated by BigchainDB GmbH.
-
-### Using Barge with Kovan
-
-If you run [Barge](https://github.com/oceanprotocol/barge) with the the `--local-kovan-node` option, then Barge will run a Kovan node on your local machine (along with everything else Barge runs). There are many blocks in the Kovan Testnet's blockchain, so it can take a long time for your local Kovan node to sync, i.e. to download a local copy of all the blocks. **In the meantime, the local Kovan node won't be able to do certain things.**
 
 ## A Ganache-Based Testnet (for Local Development)
 

--- a/content/concepts/tools.md
+++ b/content/concepts/tools.md
@@ -26,6 +26,9 @@ There is an [Ocean Protocol fork of BlockScout](https://github.com/oceanprotocol
 
 There are a few Ocean Protocol command-line interfaces (CLIs). All of them were under development at the time of writing, so you may have issues with using them.
 
-- [tuna](https://github.com/oceanprotocol/tuna) can help you use squid-py, squid-js or squid-java from the command line
+[tuna](https://github.com/oceanprotocol/tuna) can help you use squid-py, squid-js or squid-java from the command line.
+
+<repo name="tuna"></repo>
+
 - [ocean-cli](https://github.com/bigchaindb-gmbh/ocean-cli) was built using squid-java
 - [ocean-cli-py](https://github.com/bigchaindb-gmbh/ocean-cli-py) was built using squid-py

--- a/content/concepts/wallets.md
+++ b/content/concepts/wallets.md
@@ -28,7 +28,7 @@ Once your wallet is set up, it will have one or more **accounts**.
 
 Each account has several **balances**, e.g. an Ether balance, an Ocean Token balance, and maybe other balances. All balances start at zero.
 
-An account's Ether balance might be 7.1 ETH in the Ethereum Mainnet, 2.39 ETH in the Kovan testnet, and 0.1 ETH in the Nile testnet. You can't move ETH from one network to another (unless there is a special exchange or bridge set up). The same is true of Ocean Token balances.
+An account's Ether balance might be 7.1 ETH in the Ethereum Mainnet, 2.39 ETH in the Pacific network, and 0.1 ETH in the Nile testnet. You can move ETH from one network to another only with a specially setup exchange or bridge. The same is true of Ocean Token balances.
 
 Each account has one **private key**, one **public key** and one **address**. The public key and address can be calculated from the private key. You must keep the private key secret because it's what's needed to spend/transfer Ether and Ocean Tokens (or to sign transactions of any kind). You can share the address with others. In fact, if you want someone to send some Ether or Ocean Tokens to an account, you give them the account's address.
 

--- a/content/setup/keeper.md
+++ b/content/setup/keeper.md
@@ -9,13 +9,13 @@ If you want to run a [keeper node (keeper)](/concepts/components#keeper), you ha
 
 [Barge](https://github.com/oceanprotocol/barge) uses Docker Compose to run one or more keeper nodes (and other components) in Docker containers on your local machine.
 
-- If you use `--local-kovan-node` or `--local-nile-node`, then it will run one local Parity Ethereum node (as a _user node_, i.e. a non-voting node) and it will connect that node to the [Kovan Testnet](/concepts/testnets/#the-kovan-testnet) or [Nile Testnet](/concepts/testnets/#the-nile-testnet), respectively.
+- If you use `--local-pacific-node`, or `--local-nile-node`, then it will run one local Parity Ethereum node (as a _user node_, i.e. a non-voting node) and it will connect that node to the [Pacific Network](/concepts/pacific-network/) or [Nile Testnet](/concepts/testnets/#the-nile-testnet), respectively.
 - If you use `--local-spree-node` or `--local-ganache-node`, then it will run a strictly-local [Spree Testnet](/concepts/testnets/#a-spree-testnet-for-local-development) or [Ganache-Based Testnet](/concepts/testnets/#a-ganache-based-testnet-for-local-development).
 
 Barge deploys the keeper contracts to whatever keeper nodes are deployed locally.
 
-## Running a Keeper in the Nile Testnet or the Pacific Network
+## Running a Keeper in the Pacific Network or Nile Testnet
 
-If you're interested in running a keeper node (as a voting _authority node_) in the [Nile Testnet](/concepts/testnets/#the-nile-testnet) or the [Pacific Network](/concepts/pacific-network/), then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
+If you're interested in running a keeper node (as a voting _authority node_) in the [Pacific Network](/concepts/pacific-network/) or the [Nile Testnet](/concepts/testnets/#the-nile-testnet), then email <a href="mailto:info@oceanprotocol.com">info@oceanprotocol.com</a>.
 
-Note: The dev-ocean repository contains [a guide for running a keeper node in the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/keeper-setup.md) (if you have permission).
+Note: The dev-ocean repository contains [a guide for running a keeper node in the Nile Testnet](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/devops/keeper-setup.md).

--- a/content/tutorials/connect-to-networks.md
+++ b/content/tutorials/connect-to-networks.md
@@ -1,13 +1,24 @@
 ---
 title: Connect to Ocean-Related Networks
-description: How to connect to the Kovan testnet, Nile testnet and other Ocean-related networks.
+description: How to connect to the Pacific network, Nile testnet and other Ocean-related networks.
 ---
 
-## Connect to the Kovan Testnet
+## Connect to the Pacific Network
 
-Most Ethereum wallets and libraries know how to connect to the [Kovan Testnet](/concepts/testnets/#the-kovan-testnet). In MetaMask, click on the network name then click on "Kovan Test Network" in the drop-down list.
+Here are the parameters you might need to connect to the [Pacific Network](/concepts/pacific-network/):
 
-If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Kovan node, you can connect to that local Kovan node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
+| Parameter          | Value                                                      |
+| ------------------ | ---------------------------------------------------------- |
+| RPC URL (required) | [https://pacific.oceanprotocol.com][rpc-url]               |
+| ChainID            | `846353` (decimal for MetaMask) or `0xcea11` (hexadecimal) |
+| Symbol             | Whatever you like, e.g. `PACIFIC ETH`                      |
+| Nickname           | Whatever you like, e.g. `Pacific`                          |
+
+In MetaMask, click on the network name then click on `Custom RPC` in the drop-down list. Scroll down to the `New Network` section. Enter the above RPC URL. You don't need to add a port number to the end of the RPC URL. Enter the ChainID, Symbol and Nickname if you like. See the [MetaMask docs about how it uses the ChainID](https://metamask.github.io/metamask-docs/Main_Concepts/Sending_Transactions).
+
+If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Pacific node, you can connect to that local Pacific node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask). You can configure that local Pacific node by editing the files in the `barge/networks/pacific/config/` directory.
+
+[rpc-url]: https://pacific.oceanprotocol.com
 
 ## Connect to the Nile Testnet
 
@@ -28,19 +39,8 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local N
 
 When using [Barge](https://github.com/oceanprotocol/barge) to run a purely-local testnet (Spree or Ganache-based), you can connect to a local node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
 
-## Connect to the Pacific Network
+## Connect to the Kovan Testnet
 
-Here are the parameters you might need to connect to the [Pacific Network](/concepts/pacific-network/):
+Most Ethereum wallets and libraries know how to connect to the [Kovan Testnet](/concepts/testnets/#the-kovan-testnet). In MetaMask, click on the network name then click on "Kovan Test Network" in the drop-down list.
 
-| Parameter          | Value                                                   |
-| ------------------ | ------------------------------------------------------- |
-| RPC URL (required) | [https://pacific.oceanprotocol.com][rpc-url]            |
-| ChainID            | `846353` (decimal for MetaMask) or `0xcea11` (hexadecimal) |
-| Symbol             | Whatever you like, e.g. `PACIFIC ETH`                   |
-| Nickname           | Whatever you like, e.g. `Pacific`                       |
-
-In MetaMask, click on the network name then click on `Custom RPC` in the drop-down list. Scroll down to the `New Network` section. Enter the above RPC URL. You don't need to add a port number to the end of the RPC URL. Enter the ChainID, Symbol and Nickname if you like. See the [MetaMask docs about how it uses the ChainID](https://metamask.github.io/metamask-docs/Main_Concepts/Sending_Transactions).
-
-If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Pacific node, you can connect to that local Pacific node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask). You can configure that local Pacific node by editing the files in the `barge/networks/pacific/config/` directory.
-
-[rpc-url]: https://pacific.oceanprotocol.com
+If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Kovan node, you can connect to that local Kovan node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).

--- a/content/tutorials/connect-to-networks.md
+++ b/content/tutorials/connect-to-networks.md
@@ -1,6 +1,6 @@
 ---
 title: Connect to Ocean-Related Networks
-description: How to connect to the Pacific network, Nile testnet and other Ocean-related networks.
+description: Learn how to connect to the Pacific network, Nile testnet and other Ocean-related networks in your browser with MetaMask.
 ---
 
 ## Connect to the Pacific Network
@@ -9,7 +9,7 @@ Here are the parameters you might need to connect to the [Pacific Network](/conc
 
 | Parameter          | Value                                                      |
 | ------------------ | ---------------------------------------------------------- |
-| RPC URL (required) | [https://pacific.oceanprotocol.com][rpc-url]               |
+| RPC URL (required) | `https://pacific.oceanprotocol.com`                        |
 | ChainID            | `846353` (decimal for MetaMask) or `0xcea11` (hexadecimal) |
 | Symbol             | Whatever you like, e.g. `PACIFIC ETH`                      |
 | Nickname           | Whatever you like, e.g. `Pacific`                          |
@@ -18,18 +18,16 @@ In MetaMask, click on the network name then click on `Custom RPC` in the drop-do
 
 If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Pacific node, you can connect to that local Pacific node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask). You can configure that local Pacific node by editing the files in the `barge/networks/pacific/config/` directory.
 
-[rpc-url]: https://pacific.oceanprotocol.com
-
 ## Connect to the Nile Testnet
 
 Here are the parameters you might need to connect to the [Nile Testnet](/concepts/testnets/#the-nile-testnet):
 
-| Parameter          | Value                                                      |
-| ------------------ | ---------------------------------------------------------- |
-| RPC URL (required) | [https://nile.dev-ocean.com/](https://nile.dev-ocean.com/) |
-| ChainID            | `8995` (decimal for MetaMask) or `0x2323` (hexadecimal)    |
-| Symbol             | Whatever you like, e.g. `NILE ETH`                         |
-| Nickname           | Whatever you like, e.g. `Nile Testnet`                     |
+| Parameter          | Value                                                   |
+| ------------------ | ------------------------------------------------------- |
+| RPC URL (required) | `https://nile.dev-ocean.com`                            |
+| ChainID            | `8995` (decimal for MetaMask) or `0x2323` (hexadecimal) |
+| Symbol             | Whatever you like, e.g. `NILE ETH`                      |
+| Nickname           | Whatever you like, e.g. `Nile Testnet`                  |
 
 In MetaMask, click on the network name then click on `Custom RPC` in the drop-down list. Scroll down to the `New Network` section. Enter the above RPC URL. You don't need to add a port number to the end of the RPC URL. Enter the ChainID, Symbol and Nickname if you like. See the [MetaMask docs about how it uses the ChainID](https://metamask.github.io/metamask-docs/Main_Concepts/Sending_Transactions).
 
@@ -37,4 +35,4 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local N
 
 ## Connect to a Local Spree Testnet or Ganache-Based Testnet
 
-When using [Barge](https://github.com/oceanprotocol/barge) to run a purely-local testnet (Spree or Ganache-based), you can connect to a local node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
+When using [Barge](https://github.com/oceanprotocol/barge) to run a purely-local testnet (Spree or Ganache-based), you can connect to a local node at RPC URL [http://localhost:8545](http://localhost:8545) (called _Localhost 8545_ in MetaMask).

--- a/content/tutorials/connect-to-networks.md
+++ b/content/tutorials/connect-to-networks.md
@@ -38,9 +38,3 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local N
 ## Connect to a Local Spree Testnet or Ganache-Based Testnet
 
 When using [Barge](https://github.com/oceanprotocol/barge) to run a purely-local testnet (Spree or Ganache-based), you can connect to a local node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).
-
-## Connect to the Kovan Testnet
-
-Most Ethereum wallets and libraries know how to connect to the [Kovan Testnet](/concepts/testnets/#the-kovan-testnet). In MetaMask, click on the network name then click on "Kovan Test Network" in the drop-down list.
-
-If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local Kovan node, you can connect to that local Kovan node at RPC URL [http://localhost:8545](http://localhost:8545) (called "Localhost 8545" in MetaMask).

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -15,19 +15,33 @@ In MetaMask, be sure to switch from the **Main Ethereum Network** to whatever ne
 
 ## Get Ether
 
-### Get Ether for the Kovan Testnet
+### Get Ether for the Pacific Network
 
-You can get Kovan Ether (KEth), for the Kovan Testnet, from a Kovan faucet: see [the official list of Kovan faucets](https://github.com/kovan-testnet/faucet). You have to give the faucet your Kovan address (wallet account address). You can get that from MetaMask. It's a string that looks like:
+If you're connecting to the Pacific network, you can use the Ocean Faucet. A simple UI for it is deployed as part of the Commons marketplace under:
 
-```text
-0xa0A9d7f78bF293514e7cA2789A0Af689eEC99282
+- client: [commons.oceanprotocol.com/faucet](https://commons.oceanprotocol.com/faucet)
+
+This interface is set up to communicate with the deployed Ocean Faucet Server under:
+
+- server: [faucet.oceanprotocol.com](https://faucet.oceanprotocol.com)
+
+You can also communicate with that server directly and get some Nile Ether into `<YOUR ADDRESS>` using the following command:
+
+```bash
+curl --data '{"address": "<YOUR ADDRESS>", "agent": "curl"}' -H "Content-Type: application/json" -X POST https://faucet.oceanprotocol.com/faucet
 ```
+
+In the above command you only need to replace `<YOUR ADDRESS>` with your own Ethereum address.
+
+Check out the [Ocean Faucet Server repository](https://github.com/oceanprotocol/faucet) to learn more about what the server provides.
+
+The Pacific faucet has a limit of one request every 24 hours for the same Ethereum address. But don't worry, the Ether given is more than enough for interacting with the network.
 
 ### Get Ether for the Nile Testnet
 
 If you're connecting to the Nile testnet, you can use the Ocean Faucet. A simple UI for it is deployed as part of the Commons marketplace under:
 
-- client: [commons.oceanprotocol.com/faucet](https://commons.oceanprotocol.com/faucet)
+- client: [commons.nile.dev-ocean.com/faucet](https://commons.nile.dev-ocean.com/faucet)
 
 This interface is set up to communicate with the deployed Ocean Faucet Server under:
 
@@ -71,6 +85,14 @@ Details about the bootstrapped accounts can be found in [the README.md file in t
 
 ```bash
 curl --data '{"address":"<YOUR ADDRESS>"}' -H "Content-Type: application/json" -X POST localhost:3001/faucet
+```
+
+### Get Ether for the Kovan Testnet
+
+You can get Kovan Ether (KEth), for the Kovan Testnet, from a Kovan faucet: see [the official list of Kovan faucets](https://github.com/kovan-testnet/faucet). You have to give the faucet your Kovan address (wallet account address). You can get that from MetaMask. It's a string that looks like:
+
+```text
+0xa0A9d7f78bF293514e7cA2789A0Af689eEC99282
 ```
 
 ## Get Ocean Tokens

--- a/content/tutorials/get-ether-and-ocean-tokens.md
+++ b/content/tutorials/get-ether-and-ocean-tokens.md
@@ -87,14 +87,6 @@ Details about the bootstrapped accounts can be found in [the README.md file in t
 curl --data '{"address":"<YOUR ADDRESS>"}' -H "Content-Type: application/json" -X POST localhost:3001/faucet
 ```
 
-### Get Ether for the Kovan Testnet
-
-You can get Kovan Ether (KEth), for the Kovan Testnet, from a Kovan faucet: see [the official list of Kovan faucets](https://github.com/kovan-testnet/faucet). You have to give the faucet your Kovan address (wallet account address). You can get that from MetaMask. It's a string that looks like:
-
-```text
-0xa0A9d7f78bF293514e7cA2789A0Af689eEC99282
-```
-
 ## Get Ocean Tokens
 
 See the page about [Ocean Tokens](/concepts/ocean-tokens/).

--- a/content/tutorials/wallets-and-ocean-tokens.md
+++ b/content/tutorials/wallets-and-ocean-tokens.md
@@ -9,26 +9,24 @@ If you don't see any Ocean Tokens in your crypto wallet software (e.g. MetaMask 
 
 If you know the URL of a Brizo instance attached to the network you're using, then just go to that URL in your web browser and get the value of `contracts.OceanToken`.
 
+### Ethereum Mainnet
+
+The Ocean Token contract address in the Ethereum Mainnet is:
+
+[`0x985dd3D42De1e256d09e1c10F112bCCB8015AD41`](https://etherscan.io/token/0x985dd3d42de1e256d09e1c10f112bccb8015ad41)
+
+### Pacific Network
+
+The Ocean Token contract address in the [Pacific Network](/concepts/pacific-network/) is:
+
+[`0x012578f9381e876A9E2a9111Dfd436FF91A451ae`](https://submarine.oceanprotocol.com/address/0x012578f9381e876a9e2a9111dfd436ff91a451ae/transactions)
+
 ### Kovan or Nile Testnet
 
 | Testnet | Ocean Token Contract Address                 |
 | ------- | -------------------------------------------- |
-| Kovan   | `0xB57C4D626548eB8AC0B82b086721516493E2908d` |
 | Nile    | `0x9861Da395d7da984D5E8C712c2EDE44b41F777Ad` |
-
-If the above addresses are out-of-date, then you can find newer ones in the [keeper-contracts repository on GitHub](https://github.com/oceanprotocol/keeper-contracts):
-
-1. Click on the "Branch: **develop**" button and switch to the tag of the latest release (e.g. `v0.10.3`).
-1. In the `README.md` file, check the address of the OceanToken contract (in Nile or Kovan).
-1. Double-check the address by looking in the file named `zos.kovan.json` (for Kovan) or `zos.dev-8995.json` (for Nile). Search for `/OceanToken`. There should be one result and the text around it should look like:
-
-   ```json
-    "@oceanprotocol/keeper-contracts/OceanToken": [
-      {
-        "address": "0x9861Da395d7da984D5E8C712c2EDE44b41F777Ad",
-   ```
-
-   Compare the `"address"` value to the value from the `README.md` file.
+| Kovan   | `0xB57C4D626548eB8AC0B82b086721516493E2908d` |
 
 ### Spree or Ganache-Based Testnet
 
@@ -37,29 +35,17 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local S
 - `$HOME/.ocean/keeper-contracts/artifacts/OceanToken.spree.json` for Spree
 - `$HOME/.ocean/keeper-contracts/artifacts/OceanToken.development.json` for Ganache
 
-### Ethereum Mainnet
-
-The Ocean Token contract address in the Ethereum Mainnet is:
-
-`0x985dd3D42De1e256d09e1c10F112bCCB8015AD41`
-
-### Pacific Network
-
-The Ocean Token contract address in the [Pacific Network](/concepts/pacific-network/) is:
-
-`0x012578f9381e876A9E2a9111Dfd436FF91A451ae`
-
 ## Step 2: Teach Your Wallet Software about Ocean Tokens
 
 ### MetaMask Instructions
 
 1. Make sure MetaMask is connected to the correct network (Nile, Kovan or whatever). See [the tutorial about how to do that](/tutorials/connect-to-networks/).
-1. For the account you want to manage, click the `☰` (hamburger menu icon).
-1. Scroll down until the `Add Token` link is visible, then click on it.
-1. Click on `Custom Token`.
-1. Paste the OceanToken contract address (from Step 1 above) into the "Token Contract Address" field. The other two fields should auto-fill. If they don't then something is wrong.
-1. Click `Next`.
-1. Click `Add Tokens`.
+2. For the account you want to manage, click the `☰` (hamburger menu icon).
+3. Scroll down until the `Add Token` link is visible, then click on it.
+4. Click on `Custom Token`.
+5. Paste the OceanToken contract address (from Step 1 above) into the "Token Contract Address" field. The other two fields should auto-fill. If they don't then something is wrong.
+6. Click `Next`.
+7. Click `Add Tokens`.
 
 MetaMask should now show your Ocean Token (OCEAN) balance, and when you're looking at that, there should be a `Send` button to send Ocean Tokens to others. For help with that, see [the MetaMask docs about how to send tokens](https://metamask.zendesk.com/hc/en-us/articles/360015488931-How-to-Send-Tokens).
 

--- a/content/tutorials/wallets-and-ocean-tokens.md
+++ b/content/tutorials/wallets-and-ocean-tokens.md
@@ -21,12 +21,11 @@ The Ocean Token contract address in the [Pacific Network](/concepts/pacific-netw
 
 [`0x012578f9381e876A9E2a9111Dfd436FF91A451ae`](https://submarine.oceanprotocol.com/address/0x012578f9381e876a9e2a9111dfd436ff91a451ae/transactions)
 
-### Kovan or Nile Testnet
+### Nile Testnet
 
-| Testnet | Ocean Token Contract Address                 |
-| ------- | -------------------------------------------- |
-| Nile    | `0x9861Da395d7da984D5E8C712c2EDE44b41F777Ad` |
-| Kovan   | `0xB57C4D626548eB8AC0B82b086721516493E2908d` |
+The Ocean Token contract address in the [Nile Testnet](/concepts/testnets/#the-nile-testnet) is:
+
+[`0x9861Da395d7da984D5E8C712c2EDE44b41F777Ad`](https://submarine.nile.dev-ocean.com/address/0x9861Da395d7da984D5E8C712c2EDE44b41F777Ad)
 
 ### Spree or Ganache-Based Testnet
 
@@ -39,7 +38,7 @@ If you're using [Barge](https://github.com/oceanprotocol/barge) to run a local S
 
 ### MetaMask Instructions
 
-1. Make sure MetaMask is connected to the correct network (Nile, Kovan or whatever). See [the tutorial about how to do that](/tutorials/connect-to-networks/).
+1. Make sure MetaMask is connected to the correct network (Pacific, Nile or whatever). See [the tutorial about how to do that](/tutorials/connect-to-networks/).
 2. For the account you want to manage, click the `☰` (hamburger menu icon).
 3. Scroll down until the `Add Token` link is visible, then click on it.
 4. Click on `Custom Token`.

--- a/data/sidebars/concepts.yml
+++ b/data/sidebars/concepts.yml
@@ -8,10 +8,10 @@
       link: /concepts/components/
     - title: Tools
       link: /concepts/tools/
-    - title: Testnets
-      link: /concepts/testnets/
     - title: Pacific Network
       link: /concepts/pacific-network/
+    - title: Testnets
+      link: /concepts/testnets/
     - title: Ocean Tokens
       link: /concepts/ocean-tokens/
     - title: Wallet Basics

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -251,7 +251,9 @@ const createTypeDocPage = async (createPage, name, downloadUrl) => {
 // https://github.com/swagger-api/swagger-js
 const fetchSwaggerSpec = async name => {
     try {
-        const client = await Swagger(`https://${name}.nile.dev-ocean.com/spec`)
+        const client = await Swagger(
+            `https://${name}.test.oceanprotocol.com/spec`
+        )
         return client.spec // The resolved spec
 
         // client.originalSpec // In case you need it

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -200,7 +200,6 @@ const createTypeDocPage = async (createPage, name, downloadUrl) => {
         const typedocTemplate = path.resolve(
             './src/templates/Typedoc/index.jsx'
         )
-        console.log(name)
         const slug = `/references/${name}/`
 
         createPage({

--- a/src/components/DocContent.module.scss
+++ b/src/components/DocContent.module.scss
@@ -27,8 +27,11 @@
         word-wrap: normal;
         word-break: normal;
     }
+    // stylelint-disable selector-no-qualifying-type, declaration-no-important
+    a > code {
+        color: $brand-pink !important;
+    }
 
-    // stylelint-disable selector-no-qualifying-type
     :not(pre) > code,
     :not(pre) > code[class*='language-'] {
         background: darken($brand-white, 5%);
@@ -37,7 +40,7 @@
         padding-left: .3rem;
         padding-right: .3rem;
     }
-    // stylelint-enable selector-no-qualifying-type
+    // stylelint-enable selector-no-qualifying-type, declaration-no-important
 
     pre {
         display: block;
@@ -65,4 +68,20 @@
 .empty {
     font-style: italic;
     margin-bottom: $spacer * 2;
+}
+
+:global(.footnotes) {
+    font-size: $font-size-small;
+
+    p {
+        margin: 0;
+    }
+}
+
+:global(.footnote-ref) {
+    font-size: $font-size-mini;
+    font-weight: $font-weight-bold;
+    padding-left: .2rem;
+    padding-right: .2rem;
+    display: inline-block;
 }

--- a/src/components/DocFooter.jsx
+++ b/src/components/DocFooter.jsx
@@ -24,7 +24,7 @@ const DocFooter = ({ post, url, externalName }) => {
 
     return (
         <footer className={styles.footer}>
-            <a href={social.gitter}>✋ Ask a question on Gitter</a>
+            <a href={social.Gitter}>✋ Ask a question on Gitter</a>
             <a href={url} className={post && !post.html ? styles.active : null}>
                 <Pencil /> Edit this page on GitHub
                 {externalName && (

--- a/src/templates/Swagger/index.jsx
+++ b/src/templates/Swagger/index.jsx
@@ -69,7 +69,7 @@ export default class ApiSwaggerTemplate extends Component {
 
     render() {
         const { location, pageContext } = this.props
-        const { api, name } = pageContext
+        const { api } = pageContext
         const { host, basePath, info, paths } = api
         const { title, description, version, license, contact } = info
 
@@ -108,11 +108,6 @@ export default class ApiSwaggerTemplate extends Component {
                                     prepend={
                                         <span className={stylesDoc.version}>
                                             <span>v{version}</span>
-                                            <a
-                                                href={`https://app.swaggerhub.com/apis/Ocean-Protocol/${name}`}
-                                            >
-                                                past versions
-                                            </a>
                                         </span>
                                     }
                                 />


### PR DESCRIPTION
* add Aquarius & Brizo test instances, fetch API specs from it
* remove past versions swagger hub link
* add "Get Ether for the Pacific Network"
* fix Gitter link
* prioritize Pacific when networks are mentioned, Nile after that
* remove all mentions of Kovan

Closes #286
Closes #278