### PR TITLE
fix typedoc cleanup

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -220,22 +220,25 @@ const createTypeDocPage = async (createPage, name, downloadUrl) => {
                     'ocean/OceanAccounts',
                     'ocean/OceanAssets',
                     'ocean/OceanAgreements',
+                    'ocean/OceanAgreementsConditions',
+                    'ocean/OceanSecretStore',
                     'ocean/OceanVersions',
                     'ocean/Account',
                     'ocean/DID',
-                    'ocean/ServiceAgreements/ServiceAgreement',
                     'ddo/DDO',
                     'ddo/Service',
-                    'aquarius/AquariusProvider',
                     'aquarius/Aquarius',
-                    'aquarius/query/SearchQuery',
-                    'brizo/BrizoProvider',
                     'brizo/Brizo',
                     'keeper/Keeper',
+                    'keeper/ContractHandler',
+                    'keeper/EventHandler',
                     'keeper/Web3Provider',
-                    'secretstore/SecretStoreProvider',
                     'models/Config',
-                    'models/Balance'
+                    'models/Balance',
+                    'ocean/utils/OceanUtils',
+                    'ocean/utils/ServiceAgreement',
+                    'ocean/utils/WebServiceConnector',
+                    'utils/Logger'
                 ]
             }
         })

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "remark": "^11.0.1",
     "remark-github-plugin": "^1.3.1",
     "remark-react": "^6.0.0",
+    "shortid": "^2.2.15",
     "slugify": "^1.3.4",
     "smoothscroll-polyfill": "^0.4.4",
     "swagger-client": "^3.9.5"

--- a/src/templates/Typedoc/Entities.jsx
+++ b/src/templates/Typedoc/Entities.jsx
@@ -18,7 +18,11 @@ const Type = ({ type }) => {
         <div className={styles.type}>
             <span>
                 {isInternal && (
-                    <Scroll type="id" element={`${slugify(name)}`} offset={-20}>
+                    <Scroll
+                        type="id"
+                        element={`${name && slugify(name)}`}
+                        offset={-20}
+                    >
                         {type.name}
                     </Scroll>
                 )}
@@ -140,7 +144,8 @@ const PropertyWrapper = ({ property, sourceUrl, parentAnchor }) => {
     let deprecatedUse, deprecatedSlug
     if (deprecation) {
         deprecatedUse = deprecation.arguments.alternative.replace(/('|")/g, '')
-        deprecatedSlug = slugify(deprecatedUse.replace('.', '-'))
+        deprecatedSlug =
+            deprecatedUse && slugify(deprecatedUse.replace('.', '-'))
     }
 
     const sourceLink = `${sourceUrl}${fileName}#L${line}`
@@ -150,7 +155,7 @@ const PropertyWrapper = ({ property, sourceUrl, parentAnchor }) => {
             className={styles.property}
             data-private={!isPublic}
             data-deprecated={!!deprecation}
-            id={`${parentAnchor}-${slugify(name)}`}
+            id={`${parentAnchor}-${name && slugify(name)}`}
         >
             <h3 className={styles.propertyName}>{name}</h3>
 
@@ -222,7 +227,7 @@ PropertyWrapper.propTypes = {
 
 const Entities = ({ entities, sourceUrl }) =>
     entities.map(({ name, comment, children }) => (
-        <div key={name} id={slugify(name)}>
+        <div key={name} id={name && slugify(name)}>
             <h2 className={styles.entityName}>
                 <code>{name}</code>
             </h2>
@@ -233,14 +238,17 @@ const Entities = ({ entities, sourceUrl }) =>
                 </div>
             )}
 
-            {children.filter(filterByKindOfProperty).map(property => (
-                <PropertyWrapper
-                    key={`${name}/${property.id}`}
-                    property={property}
-                    sourceUrl={sourceUrl}
-                    parentAnchor={slugify(name)}
-                />
-            ))}
+            {children &&
+                children
+                    .filter(filterByKindOfProperty)
+                    .map(property => (
+                        <PropertyWrapper
+                            key={`${name}/${property.id}`}
+                            property={property}
+                            sourceUrl={sourceUrl}
+                            parentAnchor={name && slugify(name)}
+                        />
+                    ))}
         </div>
     ))
 

--- a/src/templates/Typedoc/Entities.jsx
+++ b/src/templates/Typedoc/Entities.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import slugify from 'slugify'
+import shortid from 'shortid'
 import Scroll from '../../components/Scroll'
 import styles from './Entities.module.scss'
 import { filterByKindOfProperty } from './utils'
@@ -34,13 +35,13 @@ const Type = ({ type }) => {
                     <span className={styles.typeSymbol}>&lt;</span>
                     <span>
                         {typeArguments.map((typeArgument, i) => (
-                            <span key={i}>
+                            <span key={shortid.generate()}>
                                 {i !== 0 && (
                                     <span className={styles.typeSymbol}>
                                         ,{' '}
                                     </span>
                                 )}
-                                <Type type={typeArgument} key={i} />
+                                <Type type={typeArgument} />
                             </span>
                         ))}
                     </span>
@@ -88,7 +89,7 @@ const MethodDetails = ({ property }) => {
                         return (
                             <div
                                 className={styles.parameters}
-                                key={parameter.name}
+                                key={shortid.generate()}
                             >
                                 <h5>
                                     <code>{name}</code>
@@ -227,7 +228,7 @@ PropertyWrapper.propTypes = {
 
 const Entities = ({ entities, sourceUrl }) =>
     entities.map(({ name, comment, children }) => (
-        <div key={name} id={name && slugify(name)}>
+        <div key={shortid.generate()} id={name && slugify(name)}>
             <h2 className={styles.entityName}>
                 <code>{name}</code>
             </h2>
@@ -243,7 +244,7 @@ const Entities = ({ entities, sourceUrl }) =>
                     .filter(filterByKindOfProperty)
                     .map(property => (
                         <PropertyWrapper
-                            key={`${name}/${property.id}`}
+                            key={shortid.generate()}
                             property={property}
                             sourceUrl={sourceUrl}
                             parentAnchor={name && slugify(name)}

--- a/src/templates/Typedoc/Toc.jsx
+++ b/src/templates/Typedoc/Toc.jsx
@@ -12,6 +12,7 @@ export default class Toc extends PureComponent {
     }
 
     subItems = (children, parentName) =>
+        children &&
         children.filter(filterByKindOfProperty).map(({ name, decorators }) => {
             const deprecation = (decorators || []).filter(
                 ({ name }) => name === 'deprecated'
@@ -21,7 +22,7 @@ export default class Toc extends PureComponent {
                 <li key={name}>
                     <Scroll
                         type="id"
-                        element={`${parentName}-${slugify(name)}`}
+                        element={`${parentName}-${name && slugify(name)}`}
                         data-deprecated={!!deprecation}
                         offset={-20}
                     >
@@ -36,14 +37,19 @@ export default class Toc extends PureComponent {
         const parentName = name
 
         subIds.push(
-            children.filter(filterByKindOfProperty).map(({ name }) => {
-                return `${parentName}-${slugify(name)}`
-            })
+            children &&
+                children.filter(filterByKindOfProperty).map(({ name }) => {
+                    return `${parentName}-${name && slugify(name)}`
+                })
         )
 
         return (
             <li key={name}>
-                <Scroll type="id" element={`${slugify(name)}`} offset={-20}>
+                <Scroll
+                    type="id"
+                    element={`${name && slugify(name)}`}
+                    offset={-20}
+                >
                     <code>{name}</code>
                 </Scroll>
                 <Scrollspy

--- a/src/templates/Typedoc/Toc.jsx
+++ b/src/templates/Typedoc/Toc.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import slugify from 'slugify'
+import shortid from 'shortid'
 import Scrollspy from 'react-scrollspy'
 import Scroll from '../../components/Scroll'
 import { filterByKindOfProperty } from './utils'
@@ -19,7 +20,7 @@ export default class Toc extends PureComponent {
             )[0] // Assuming deprecated annotation
 
             return (
-                <li key={name}>
+                <li key={shortid.generate()}>
                     <Scroll
                         type="id"
                         element={`${parentName}-${name && slugify(name)}`}
@@ -44,7 +45,7 @@ export default class Toc extends PureComponent {
         )
 
         return (
-            <li key={name}>
+            <li key={shortid.generate()}>
                 <Scroll
                     type="id"
                     element={`${name && slugify(name)}`}

--- a/src/templates/Typedoc/utils.js
+++ b/src/templates/Typedoc/utils.js
@@ -29,17 +29,18 @@ export const cleanTypedocData = (data, useClasses) => {
     return cleanData
 }
 
-// more kinds: 'Property', 'Class'
+// more kinds: 'Property', 'Enumeration'
 const showKindOfProperty = {
     Method: { onlyPublic: true },
-    Property: { onlyPublic: true },
-    Class: { onlyPublic: true },
-    Interface: { onlyPublic: false }
+    Property: { onlyPublic: true }
 }
 
 export const filterByKindOfProperty = ({ kindString, flags }) => {
     const config = showKindOfProperty[kindString]
     if (!config) return
+
+    // filter out static methods by default
+    if (flags.isStatic) return
 
     if (config.onlyPublic && !flags.isPublic) return
 

--- a/src/templates/Typedoc/utils.js
+++ b/src/templates/Typedoc/utils.js
@@ -2,17 +2,28 @@ export const cleanTypedocData = (data, useClasses) => {
     const nodes = data.children
 
     const cleanData = nodes
-        .map(node => ({
-            ...node,
-            name: node.name.replace(/"/g, '').replace('src/', ''),
-            child: node.children && node.children[0]
-        }))
+        .map(node => {
+            const child =
+                node.children &&
+                node.children.filter(
+                    ({ kindString }) => kindString === 'Class'
+                )[0]
+
+            return {
+                ...node,
+                name: node.name.replace(/"/g, '').replace('src/', ''),
+                child
+            }
+        })
         .filter(({ name }) => (useClasses || []).includes(name))
         .sort((a, b) => useClasses.indexOf(a.name) - useClasses.indexOf(b.name))
         .map(({ child }) => child)
         .map(node => ({
             ...node,
-            children: node.children.sort((a, b) => a.id - b.id)
+            children:
+                node &&
+                node.children &&
+                node.children.sort((a, b) => a.id - b.id)
         }))
 
     return cleanData
@@ -21,7 +32,9 @@ export const cleanTypedocData = (data, useClasses) => {
 // more kinds: 'Property', 'Class'
 const showKindOfProperty = {
     Method: { onlyPublic: true },
-    Property: { onlyPublic: true }
+    Property: { onlyPublic: true },
+    Class: { onlyPublic: true },
+    Interface: { onlyPublic: false }
 }
 
 export const filterByKindOfProperty = ({ kindString, flags }) => {


### PR DESCRIPTION
The source typedoc json is structured inconsistent so our cleanup function was omitting some stuff. This PR makes a lot more show up, consistent to what's defined in the classes array in gatsby-node.js

https://betadocs.oceanprotocol.com/references/squid-js/

closes #322 