### PR TITLE
include Squid spec under /concepts

### DIFF
--- a/data/sidebars/concepts.yml
+++ b/data/sidebars/concepts.yml
@@ -23,6 +23,8 @@
       link: /concepts/architecture/
     - title: Secret Store
       link: /concepts/secret-store/
+    - title: Squid
+      link: /concepts/squid/
 
 - group: Contribute
   items:


### PR DESCRIPTION
Output the [squid spec from dev-ocean](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/architecture/squid.md) in the docs under /concepts/squid

Requires https://github.com/oceanprotocol/dev-ocean/pull/159