### PR TITLE
Merge fix for issue #449

### DIFF
--- a/data/sections.yml
+++ b/data/sections.yml
@@ -4,7 +4,7 @@
   color: purple
 
 - title: Tutorials
-  description: Build an Ocean-powered React app, and more.
+  description: On launching a marketplace, running compute-to-data, and more.
   link: /tutorials/introduction/
   color: orange
 


### PR DESCRIPTION
"Tutorials" header still refers to React, which is obsolete#449

closes #449