### PR TITLE
switch market-stats for ocean-subgraph in repo list

### DIFF
--- a/data/repositories.yml
+++ b/data/repositories.yml
@@ -25,7 +25,7 @@
       links:
         - name: Live
           url: https://market.oceanprotocol.com
-    - name: market-stats
+    - name: ocean-subgraph
     - name: market-purgatory
     - name: list-purgatory
 


### PR DESCRIPTION
`market-stats` will be removed, and new devs should start with the subgraph