### PR TITLE
Added OCEAN token address and fixed some dead links

### DIFF
--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -17,6 +17,7 @@ MetaMask and other ERC20 wallets default to Ethereum mainnet, therefore your wal
 
 - ETH: [Exchanges to purchase](https://www.coingecko.com/en/coins/ethereum#markets)
 - OCEAN: [Official exchanges to purchase](https://oceanprotocol.com/token#get).
+  - Token address: `0x967da4048cD07aB37855c090aAF366e4ce1b9F48`
 
 **Additional Components**
 
@@ -38,6 +39,7 @@ In MetaMask and other ERC20 wallets, click on the network name dropdown, then se
 
 - ETH: [Faucet for Ropsten](https://faucet.dimensions.network/). You may find others by [searching](https://www.google.com/search?q=ropsten+ether+faucet&oq=ropsten+ether+faucet).
 - OCEAN: [Faucet for Ropsten](https://faucet.ropsten.oceanprotocol.com/)
+  - Token address: `0x8967BCF84170c91B0d24D4302C2376283b0B3a07`
 
 **Additional Components**
 
@@ -59,6 +61,7 @@ In MetaMask and other ERC20 wallets, click on the network name dropdown, then se
 
 - ETH: [Faucet for Rinkeby](https://faucet.rinkeby.io/). You may find others by [searching](https://www.google.com/search?q=rinkeby+ether+faucet&oq=rinkeby+ether+faucet).
 - OCEAN: [Faucet for Rinkeby](https://faucet.rinkeby.oceanprotocol.com/)
+  - Token address: `0x5e8DCB2AfA23844bcc311B00Ad1A0C30025aADE9`
 
 **Additional Components**
 
@@ -83,7 +86,7 @@ Alternatively, you can run Ganache independently. Install it according to [the G
 **Get Tokens**
 
 - ETH: By default, Ganache creates several Ethereum accounts at launch, gives each some ETH, and makes their private keys available in the logs. You can also instruct Ganache to give ETH to specific Ethereum addresses.
-- OCEAN: You can deploy an ERC20 token with label OCEAN. You’ll see examples in the quickstarts for the Ocean JavaScript and Python drivers.
+- OCEAN: You can deploy an ERC20 token with label OCEAN. At a minimum, the token needs to be ERC20Detailed and ERC20Capped. You’ll see examples in the quickstarts for the Ocean JavaScript and Python drivers.
 
 ## Chain IDs
 

--- a/content/tutorials/marketplace.md
+++ b/content/tutorials/marketplace.md
@@ -15,9 +15,9 @@ In Ocean, marketplaces and publishers are different roles. A common setup is for
 
 Here are some approaches:
 
-- Fork [Ocean Market](/references/market/) code
-- Build from [Ocean React hooks](/references/react/).
-- Build up from [ocean.js](/references/ocean.js/) or [ocean.py](https://github.com/oceanprotocol/ocean.py) drivers
+- Fork [Ocean Market](https://github.com/oceanprotocol/market) code.
+- Build from [Ocean React hooks](https://github.com/oceanprotocol/react).
+- Build up from [ocean.js](https://github.com/oceanprotocol/ocean.js) or [ocean.py](https://github.com/oceanprotocol/ocean.py) drivers.
 
 ## Prepare Some Initial Data Assets
 

--- a/content/tutorials/wallets-and-ocean-tokens.md
+++ b/content/tutorials/wallets-and-ocean-tokens.md
@@ -9,7 +9,21 @@ If you don't see any Ocean Tokens in your crypto wallet software (e.g. MetaMask 
 
 Almost all ERC-20 wallets require these values for adding a custom token:
 
+**Mainnet**
+
 - Contract Address: `0x967da4048cD07aB37855c090aAF366e4ce1b9F48`
+- Symbol: `OCEAN`
+- Decimals: `18`
+
+**Rinkeby**
+
+- Contract Address: `0x8967BCF84170c91B0d24D4302C2376283b0B3a07`
+- Symbol: `OCEAN`
+- Decimals: `18`
+
+**Ropsten**
+
+- Contract Address: `0x5e8DCB2AfA23844bcc311B00Ad1A0C30025aADE9`
 - Symbol: `OCEAN`
 - Decimals: `18`
 


### PR DESCRIPTION
Fixes # .

There were some dead links in the _content/tutorials/marketplace.md_ file. They were updated to point to the corresponding GitHub repositories.

Changes proposed in this PR:

_content/concepts/network.md_ file:
-  Added the OCEAN token addresses for their corresponding networks. This is useful to have at hand.
-  For custom deployments, OCEAN needs to be at least ERC20Detailed and ERC20Capped. This was added in the steps detailing that OCEAN can be deployed as an ERC20 token

_content/tutorials/wallets-and-ocean-tokens.md_ file:
-  Added the OCEAN token addresses for their corresponding networks. This is useful to have at hand, especially to add the token to MetaMask and test the MarketPlace quickly.
