### PR TITLE
Fix-#638: Remove gatsby-transformer-remark plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -171,7 +171,6 @@ module.exports = {
         path: `${__dirname}/markdowns/markdowns`,
         name: 'markdowns'
       }
-    },
-    'gatsby-transformer-remark'
+    }
   ]
 }


### PR DESCRIPTION
Fixes #638 .

Changes proposed in this PR:

- Fix missing image in the rendered docs.