### PR TITLE
Show correct Aquarius rest endpoints

### DIFF
--- a/src/templates/Swagger/Paths.jsx
+++ b/src/templates/Swagger/Paths.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import slugify from 'slugify'
-import { cleanPathKey } from './utils'
 import styles from './Paths.module.scss'
 import stylesDoc from '../Doc.module.scss'
 
@@ -142,9 +141,9 @@ Method.propTypes = {
 
 const Paths = ({ paths }) =>
   Object.entries(paths).map(([key, value]) => (
-    <div key={key} id={slugify(cleanPathKey(key))}>
+    <div key={key} id={slugify(key)}>
       <h2 className={stylesDoc.pathName}>
-        <code>{cleanPathKey(key)}</code>
+        <code>{key}</code>
       </h2>
 
       {Object.entries(value).map(([key, value]) => (

--- a/src/templates/Swagger/Toc.jsx
+++ b/src/templates/Swagger/Toc.jsx
@@ -9,29 +9,47 @@ import stylesSidebar from '../../components/Sidebar.module.scss'
 const Toc = ({ data }) => {
   const Ids = []
 
-  const items = Object.keys(data.paths).map((key) => {
-    Ids.push(slugify(cleanPathKey(key)))
+  const itemsV1 = Object.keys(data.paths)
+    .filter((key) => key.startsWith('/api/v1/aquarius'))
+    .map((key) => {
+      Ids.push(slugify(key))
 
-    return (
-      <li key={key}>
-        <Scroll
-          type="id"
-          element={`${slugify(cleanPathKey(key))}`}
-          offset={-20}
-        >
-          <code>{cleanPathKey(key)}</code>
-        </Scroll>
-      </li>
-    )
-  })
+      return (
+        <li key={key}>
+          <Scroll type="id" element={`${slugify(key)}`} offset={-20}>
+            <code>{cleanPathKey(key)}</code>
+          </Scroll>
+        </li>
+      )
+    })
 
+  const itemsOther = Object.keys(data.paths)
+    .filter((key) => !key.startsWith('/api/v1/aquarius'))
+    .map((key) => {
+      Ids.push(slugify(key))
+
+      return (
+        <li key={key}>
+          <Scroll type="id" element={`${slugify(key)}`} offset={-20}>
+            <code>{key}</code>
+          </Scroll>
+        </li>
+      )
+    })
   return (
     <Scrollspy
       items={Ids}
       currentClassName={stylesSidebar.scrollspyActive}
       offset={-100}
     >
-      {items}
+      <code>/api/v1/aquarius</code>
+      <ul>{itemsV1}</ul>
+      {itemsOther.length ? (
+        <>
+          <code>Other REST endpoints</code>
+          <ul>{itemsOther}</ul>
+        </>
+      ) : null}
     </Scrollspy>
   )
 }

--- a/src/templates/Swagger/utils.js
+++ b/src/templates/Swagger/utils.js
@@ -4,10 +4,5 @@ export const cleanPathKey = (key) => {
   if (key.includes('aquarius')) {
     keyCleaned = key.replace(/\/api\/v1\/aquarius/gi, '')
   }
-
-  if (key.includes('brizo')) {
-    keyCleaned = key.replace(/\/api\/v1\/brizo/gi, '')
-  }
-
   return keyCleaned
 }


### PR DESCRIPTION
Fixes #697 

Changes proposed in this PR:

- Group Aquarius URLs in 2 parts: 1. Starting with `/api/v1/aquarius` and `others`

There are 2 ways to fix the issue.

1st:
Show complete url in toc as below, but the urls are too long and difficult to read.

![1](https://user-images.githubusercontent.com/16358982/128746664-ce21e992-ff5f-45c7-999a-c26935d84bfc.PNG)


2nd:
Group urls in 2 parts as implemented in code.