### PR TITLE
Freeze v3 version of repositories

### DIFF
--- a/config.js
+++ b/config.js
@@ -98,5 +98,17 @@ module.exports = {
       name: 'provider',
       url: 'https://provider.mainnet.oceanprotocol.com/spec'
     }
-  ]
+  ],
+  v3Versions: {
+    'ocean.js': 'v0.19.0',
+    'ocean.py': 'v0.8.5',
+    contracts: 'v0.6.9',
+    aquarius: 'v3.1.1',
+    provider: 'v0.4.23',
+    'ocean-subgraph': 'v1.2.0',
+    'operator-service': 'v1.0.1',
+    'operator-engine': 'v1.0.4',
+    'pod-configuration': 'v1.0.10',
+    'pod-publishing': 'v1.0.1'
+  }
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -133,18 +133,11 @@ exports.createPages = ({ graphql, actions }) => {
 
         await createDeploymentsPage(createPage)
         // API: ocean.js
-        const lastRelease =
-          result.data.oceanJs.repository.releases.edges.filter(
-            ({ node }) =>
-              !node.isPrerelease &&
-              !node.isDraft &&
-              node.releaseAssets.edges.length > 0
-          )[0].node.releaseAssets.edges[0].node
 
         await createTypeDocPage(
           createPage,
           result.data.oceanJs.repository.name,
-          lastRelease.downloadUrl
+          'https://github.com/oceanprotocol/ocean.js/releases/download/v0.19.0/lib.json'
         )
 
         //

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,7 @@ const path = require('path')
 const { createFilePath } = require('gatsby-source-filesystem')
 const Swagger = require('swagger-client')
 const { redirects, swaggerComponents } = require('./config')
+const { v3Versions } = require('./config')
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
@@ -137,7 +138,7 @@ exports.createPages = ({ graphql, actions }) => {
         await createTypeDocPage(
           createPage,
           result.data.oceanJs.repository.name,
-          'https://github.com/oceanprotocol/ocean.js/releases/download/v0.19.0/lib.json'
+          `https://github.com/oceanprotocol/ocean.js/releases/download/${v3Versions['ocean.js']}/lib.json`
         )
 
         //

--- a/src/components/Repository/Title.jsx
+++ b/src/components/Repository/Title.jsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styles from './Title.module.scss'
+import { v3Versions } from '../../../config'
 
 import { ReactComponent as Forks } from '../../images/forks.svg'
 
 export default function Title({ name, isFork, parent, releases, url }) {
+  const releaseVersion = v3Versions[name]
+    ? v3Versions[name]
+    : releases.edges[0] && releases.edges[0].node.tag.name
+
   return (
     <h1 className={styles.title}>
       <a href={url}>
@@ -16,11 +21,11 @@ export default function Title({ name, isFork, parent, releases, url }) {
       </a>
       {releases.edges[0] && (
         <a
-          href={`${url}/releases`}
+          href={`${url}/releases/tag/${releaseVersion}`}
           className={styles.repositoryRelease}
           title="Latest release"
         >
-          {releases.edges[0].node.tag.name}
+          {releaseVersion}
         </a>
       )}
     </h1>


### PR DESCRIPTION
Fixes #930

Changes proposed in this PR:

- Freeze v3 versions of Ocean components
- Route to specific release version on clicking the version in home page.