### PR TITLE
V4: Update supported networks

### DIFF
--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -29,6 +29,31 @@ Ethereum mainnet is a production network. In MetaMask and other ERC20 wallets, c
 | Provider     | `https://v4.provider.mainnet.oceanprotocol.com`                                   |
 | Subgraph     | `https://v4.subgraph.mainnet.oceanprotocol.com`                                   |
 
+## Polygon Mainnet
+
+Ocean is deployed to Polygon Mainnet, another production network. Polygon’s native token is MATIC.
+If you don’t find Polygon as a predefined network in your wallet, you can connect to it manually via Polygon's guide [here](https://docs.polygon.technology/docs/develop/metamask/config-polygon-on-metamask/#add-the-polygon-network-manually).
+
+**Tokens**
+
+- Matic:
+  - Native token to pay transaction fees
+- Matic OCEAN:
+  - Address: [0x282d8efCe846A88B159800bd4130ad77443Fa1A1](https://polygonscan.com/token/0x282d8efce846a88b159800bd4130ad77443fa1a1)
+
+**Additional Components**
+
+| What         | URL                                                                              |
+| ------------ | -------------------------------------------------------------------------------- |
+| Explorer     | https://polygonscan.com                                                          |
+| Ocean Market | Point wallet to Ploygon Mainnet network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.polygon.oceanprotocol.com/`                                 |
+| Subgraph     | `https://v4.subgraph.polygon.oceanprotocol.com/`                                 |
+
+**Bridge**
+
+Check our Polygon Bridge [guide](/tutorials/polygon-bridge/) to learn how you can deposit, withdraw and send tokens.
+
 ## Binance Smart Chain
 
 Ocean is deployed to Binance Smart Chain (BSC), another production network. BSC’s native token is BNB - the Binance token.
@@ -53,7 +78,7 @@ If you don’t find BSC as a predefined network in your wallet, you can connect 
 
 **Bridge**
 
-Check our BSC Bridge [guide](/tutorials/bsc-bridge/) to learn how you can deposit, withdraw and send token
+Check our BSC Bridge [guide](/tutorials/bsc-bridge/) to learn how you can deposit, withdraw and send tokens.
 
 ## Energy Web Chain
 

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -73,6 +73,28 @@ If you don’t find Energy Web Chain as a predefined network in your wallet, you
 | Provider     | `https://v4.provider.energyweb.oceanprotocol.com/`                                |
 | Subgraph     | `https://v4.subgraph.energyweb.oceanprotocol.com`                                 |
 
+## Moonriver
+
+Ocean is deployed to [Moonriver](https://docs.moonbeam.network/builders/get-started/networks/moonriver/), another production network. Moonriver’s native token is MOVR.
+
+If you don’t find Moonriver as a predefined network in your wallet, you can connect to it using the guide [here](https://docs.moonbeam.network/builders/get-started/networks/moonriver/#connect-metamask).
+
+**Tokens**
+
+- Moonriver MOVR:
+  - Native token to pay transaction fees.
+- Moonriver OCEAN:
+  - Address: [0x99C409E5f62E4bd2AC142f17caFb6810B8F0BAAE](https://blockscout.moonriver.moonbeam.network/token/0x99C409E5f62E4bd2AC142f17caFb6810B8F0BAAE/token-transfers)
+
+**Additional Components**
+
+| What         | URL                                                                               |
+| ------------ | --------------------------------------------------------------------------------- |
+| Explorer     | https://blockscout.moonriver.moonbeam.network                                     |
+| Ocean Market | Point wallet to Energy Web Chain network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.moonriver.oceanprotocol.com`                                 |
+| Subgraph     | `https://v4.subgraph.moonriver.oceanprotocol.com`                                 |
+
 ## Ropsten
 
 Ropsten is a test network.

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -75,7 +75,7 @@ If you don’t find Energy Web Chain as a predefined network in your wallet, you
 
 **Bridge**
 
-Check our BSC Bridge [guide](/tutorials/bsc-bridge/) to learn how you can deposit, withdraw and send tokens.
+Check our BSC Bridge [guide](https://bridge.carbonswap.exchange) to learn how you can deposit, withdraw and send tokens.
 
 ## Moonriver
 

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -51,6 +51,10 @@ If you don’t find BSC as a predefined network in your wallet, you can connect 
 | Provider     | `https://v4.provider.bsc.oceanprotocol.com`                                          |
 | Subgraph     | `https://v4.subgraph.bsc.oceanprotocol.com`                                          |
 
+**Bridge**
+
+Check our BSC Bridge [guide](/tutorials/bsc-bridge/) to learn how you can deposit, withdraw and send token
+
 ## Energy Web Chain
 
 Ocean is deployed to [Energy Web Chain](https://energy-web-foundation.gitbook.io/energy-web/technology/the-stack/trust-layer-energy-web-chain), another production network. Energy Web’s native token is EWT.
@@ -75,7 +79,7 @@ If you don’t find Energy Web Chain as a predefined network in your wallet, you
 
 **Bridge**
 
-Check our BSC Bridge [guide](https://bridge.carbonswap.exchange) to learn how you can deposit, withdraw and send tokens.
+Use the link [here](https://bridge.carbonswap.exchange) to bridge the assets between EWC and Ethereum mainnet.
 
 ## Moonriver
 

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -22,12 +22,12 @@ Ethereum mainnet is a production network. In MetaMask and other ERC20 wallets, c
 
 **Additional Components**
 
-| What         | URL                                                                      |
-| ------------ | ------------------------------------------------------------------------ |
-| Explorer     | https://etherscan.io                                                     |
-| Ocean Market | Point wallet to Ropsten network, at https://v4.market.oceanprotocol.com/ |
-| Provider     | `https://v4.provider.mainnet.oceanprotocol.com`                          |
-| Subgraph     | `https://v4.subgraph.mainnet.oceanprotocol.com`                          |
+| What         | URL                                                                               |
+| ------------ | --------------------------------------------------------------------------------- |
+| Explorer     | https://etherscan.io                                                              |
+| Ocean Market | Point wallet to Ethereum Mainnet network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.mainnet.oceanprotocol.com`                                   |
+| Subgraph     | `https://v4.subgraph.mainnet.oceanprotocol.com`                                   |
 
 ## Binance Smart Chain
 
@@ -44,12 +44,34 @@ If you don’t find BSC as a predefined network in your wallet, you can connect 
 
 **Additional Components**
 
-| What         | URL                                                                      |
-| ------------ | ------------------------------------------------------------------------ |
-| Explorer     | https://bscscan.com/                                                     |
-| Ocean Market | Point wallet to Ropsten network, at https://v4.market.oceanprotocol.com/ |
-| Provider     | `https://v4.provider.bsc.oceanprotocol.com`                              |
-| Subgraph     | `https://v4.subgraph.bsc.oceanprotocol.com`                              |
+| What         | URL                                                                                  |
+| ------------ | ------------------------------------------------------------------------------------ |
+| Explorer     | https://bscscan.com/                                                                 |
+| Ocean Market | Point wallet to Binance Smart Chain network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.bsc.oceanprotocol.com`                                          |
+| Subgraph     | `https://v4.subgraph.bsc.oceanprotocol.com`                                          |
+
+## Energy Web Chain
+
+Ocean is deployed to [Energy Web Chain](https://energy-web-foundation.gitbook.io/energy-web/technology/the-stack/trust-layer-energy-web-chain), another production network. Energy Web’s native token is EWT.
+
+If you don’t find Energy Web Chain as a predefined network in your wallet, you can connect to it using the guide [here](https://energy-web-foundation.gitbook.io/energy-web/how-tos-and-tutorials/connect-to-energy-web-chain-main-network-with-metamash).
+
+**Tokens**
+
+- Energy Web Chain EWT:
+  - Native token to pay transaction fees.
+- Energy Web Chain OCEAN:
+  - Address: [0x593122aae80a6fc3183b2ac0c4ab3336debee528](https://explorer.energyweb.org/token/0x593122aae80a6fc3183b2ac0c4ab3336debee528)
+
+**Additional Components**
+
+| What         | URL                                                                               |
+| ------------ | --------------------------------------------------------------------------------- |
+| Explorer     | https://explorer.energyweb.org/                                                   |
+| Ocean Market | Point wallet to Energy Web Chain network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.energyweb.oceanprotocol.com/`                                |
+| Subgraph     | `https://v4.subgraph.energyweb.oceanprotocol.com`                                 |
 
 ## Ropsten
 

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -73,6 +73,10 @@ If you don’t find Energy Web Chain as a predefined network in your wallet, you
 | Provider     | `https://v4.provider.energyweb.oceanprotocol.com/`                                |
 | Subgraph     | `https://v4.subgraph.energyweb.oceanprotocol.com`                                 |
 
+**Bridge**
+
+Check our BSC Bridge [guide](/tutorials/bsc-bridge/) to learn how you can deposit, withdraw and send tokens.
+
 ## Moonriver
 
 Ocean is deployed to [Moonriver](https://docs.moonbeam.network/builders/get-started/networks/moonriver/), another production network. Moonriver’s native token is MOVR.
@@ -94,6 +98,10 @@ If you don’t find Moonriver as a predefined network in your wallet, you can co
 | Ocean Market | Point wallet to Energy Web Chain network, at https://v4.market.oceanprotocol.com/ |
 | Provider     | `https://v4.provider.moonriver.oceanprotocol.com`                                 |
 | Subgraph     | `https://v4.subgraph.moonriver.oceanprotocol.com`                                 |
+
+**Bridge**
+
+Use [Anyswap](https://anyswap.exchange/#/bridge) to bridge between ETH Mainnet and Moonriver.
 
 ## Ropsten
 

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -9,7 +9,47 @@ In each network, you’ll need ETH to pay for gas, and OCEAN for certain Ocean a
 
 The universal Aquarius Endpoint is `https://v4.aquarius.oceanprotocol.com`.
 
+## Ethereum Mainnet
 
+Ethereum mainnet is a production network. In MetaMask and other ERC20 wallets, click on the network name dropdown, then select _Ethereum mainnet_.
+
+**Tokens**
+
+- Mainnet ETH:
+  - Native token to pay transaction fees
+- Mainnet OCEAN:
+  - Address: [0x967da4048cD07aB37855c090aAF366e4ce1b9F48](https://etherscan.io/token/0x967da4048cD07aB37855c090aAF366e4ce1b9F48)
+
+**Additional Components**
+
+| What         | URL                                                                      |
+| ------------ | ------------------------------------------------------------------------ |
+| Explorer     | https://etherscan.io                                                     |
+| Ocean Market | Point wallet to Ropsten network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.mainnet.oceanprotocol.com`                          |
+| Subgraph     | `https://v4.subgraph.mainnet.oceanprotocol.com`                          |
+
+## Binance Smart Chain
+
+Ocean is deployed to Binance Smart Chain (BSC), another production network. BSC’s native token is BNB - the Binance token.
+
+If you don’t find BSC as a predefined network in your wallet, you can connect to it manually via Binance’s guide [here](https://academy.binance.com/en/articles/connecting-metamask-to-binance-smart-chain).
+
+**Tokens**
+
+- BSC BNB:
+  - Native token to pay transaction fees.
+- BSC OCEAN:
+  - Address: [0xdce07662ca8ebc241316a15b611c89711414dd1a](https://bscscan.com/token/0xdce07662ca8ebc241316a15b611c89711414dd1a)
+
+**Additional Components**
+
+| What         | URL                                                                      |
+| ------------ | ------------------------------------------------------------------------ |
+| Explorer     | https://bscscan.com/                                                     |
+| Ocean Market | Point wallet to Ropsten network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.bsc.oceanprotocol.com`                              |
+| Subgraph     | `https://v4.subgraph.bsc.oceanprotocol.com`                              |
 
 ## Ropsten
 
@@ -32,8 +72,8 @@ In MetaMask and other ERC20 wallets, click on the network name dropdown, then se
 | ------------ | -------------------------------------------------------------------- |
 | Explorer     | https://ropsten.etherscan.io                                         |
 | Ocean Market | Point wallet to Ropsten network, at https://market.oceanprotocol.com |
-| Provider     | `https://v4.provider.ropsten.oceanprotocol.com`                         |
-| Subgraph     | `https://v4.subgraph.ropsten.oceanprotocol.com`                         |
+| Provider     | `https://v4.provider.ropsten.oceanprotocol.com`                      |
+| Subgraph     | `https://v4.subgraph.ropsten.oceanprotocol.com`                      |
 
 ## Rinkeby
 
@@ -56,8 +96,8 @@ In MetaMask and other ERC20 wallets, click on the network name dropdown, then se
 | ------------ | -------------------------------------------------------------------- |
 | Explorer     | https://rinkeby.etherscan.io                                         |
 | Ocean Market | Point wallet to Rinkeby network, at https://market.oceanprotocol.com |
-| Provider     | `https://v4.provider.rinkeby.oceanprotocol.com`                         |
-| Subgraph     | `https://v4.subgraph.rinkeby.oceanprotocol.com`                         |
+| Provider     | `https://v4.provider.rinkeby.oceanprotocol.com`                      |
+| Subgraph     | `https://v4.subgraph.rinkeby.oceanprotocol.com`                      |
 
 ## Mumbai
 
@@ -80,9 +120,8 @@ If you don't find Mumbai as a predefined network in your wallet, you can connect
 | ------------ | ------------------------------------------------------------------- |
 | Explorer     | https://mumbai.polygonscan.com                                      |
 | Ocean Market | Point wallet to Mumbai network, at https://market.oceanprotocol.com |
-| Provider     | `https://v4.provider.mumbai.oceanprotocol.com`                         |
-| Subgraph     | `https://v4.subgraph.mumbai.oceanprotocol.com`                         |
-
+| Provider     | `https://v4.provider.mumbai.oceanprotocol.com`                      |
+| Subgraph     | `https://v4.subgraph.mumbai.oceanprotocol.com`                      |
 
 ## Moonbase
 
@@ -101,14 +140,12 @@ If you don't find Moonbase as a predefined network in your wallet, you can conne
 
 **Additional Components**
 
-| What         | URL                                                                 |
-| ------------ | ------------------------------------------------------------------- |
-| Explorer     | https://moonbase.moonscan.io/                                      |
+| What         | URL                                                                   |
+| ------------ | --------------------------------------------------------------------- |
+| Explorer     | https://moonbase.moonscan.io/                                         |
 | Ocean Market | Point wallet to Moonbase network, at https://market.oceanprotocol.com |
-| Provider     | `https://v4.provider.moonbase.oceanprotocol.com/`                       |
-| Subgraph     | `https://v4.subgraph.moonbase.oceanprotocol.com`                         |
-
-
+| Provider     | `https://v4.provider.moonbase.oceanprotocol.com/`                     |
+| Subgraph     | `https://v4.subgraph.moonbase.oceanprotocol.com`                      |
 
 ## Local / Ganache
 

--- a/content/concepts/networks.md
+++ b/content/concepts/networks.md
@@ -92,12 +92,12 @@ If you don’t find Moonriver as a predefined network in your wallet, you can co
 
 **Additional Components**
 
-| What         | URL                                                                               |
-| ------------ | --------------------------------------------------------------------------------- |
-| Explorer     | https://blockscout.moonriver.moonbeam.network                                     |
-| Ocean Market | Point wallet to Energy Web Chain network, at https://v4.market.oceanprotocol.com/ |
-| Provider     | `https://v4.provider.moonriver.oceanprotocol.com`                                 |
-| Subgraph     | `https://v4.subgraph.moonriver.oceanprotocol.com`                                 |
+| What         | URL                                                                        |
+| ------------ | -------------------------------------------------------------------------- |
+| Explorer     | https://blockscout.moonriver.moonbeam.network                              |
+| Ocean Market | Point wallet to Moonriver network, at https://v4.market.oceanprotocol.com/ |
+| Provider     | `https://v4.provider.moonriver.oceanprotocol.com`                          |
+| Subgraph     | `https://v4.subgraph.moonriver.oceanprotocol.com`                          |
 
 **Bridge**
 

--- a/content/tutorials/bsc-bridge.md
+++ b/content/tutorials/bsc-bridge.md
@@ -1,6 +1,6 @@
 ---
 title: Binance Smart Chain (BSC)
-description: 
+description:
 ---
 
 ## Intro to BSC's Bridge
@@ -15,5 +15,5 @@ The article [How to Get Started with BSC](https://academy.binance.com/en/article
 ## Links
 
 - [BSC Wallet Support](https://docs.binance.org/wallets/bsc-wallets.html). Includes MetaMask and Trust Wallet.
-- [BSC Bridge](https://wallet.matic.network/bridge)
+- [BSC Bridge](https://www.bnbchain.org/en/bridge)
 - [How to set up a custom network in MetaMask](/tutorials/metamask-setup/#set-up-custom-network)


### PR DESCRIPTION
Fixes #1011

Changes proposed in this PR:

Updated docs mention support for following production networks:
- [x] Ethereum mainnet
- [x] Moonriver
- [x] BSC
- [x] EnergyWeb
- [x] Polygon

Mention bridge support for:
- [x] BSC
- [x] Moonriver 
- [x] Polygon
