### PR TITLE
Updating partners page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -52,7 +52,7 @@
   * [Contributing](core-concepts/contributing.md)
     * [Contributor Code of Conduct](core-concepts/code-of-conduct.md)
     * [Legal Requirements](core-concepts/legal-reqs.md)
-  * [Projects using Ocean Protocol](building-with-ocean/projects-using-ocean.md)
+  * [Partners & Collaborators](building-with-ocean/projects-using-ocean.md)
 * [Rewards](rewards/veOcean-Data-Farming-Tutorial.md)
 * [API References](api-references/README.md)
   * [Aquarius REST API](api-references/aquarius-rest-api.md)

--- a/building-with-ocean/projects-using-ocean.md
+++ b/building-with-ocean/projects-using-ocean.md
@@ -3,7 +3,7 @@ title: Partners & Collaborators
 description: We work with many competent partners who understand the value of Ocean
 ---
 
-We work closely with our collaborators and service partners to iterate on the network's underlying technology, and to deliver world-class Web3 experiences built on top of Ocean Protocol to enterprises. An up to date list of our partners and collaborators is maintained on our [main site](https://oceanprotocol.com/collaborators).
+We work closely with our collaborators and service partners to iterate on our underlying technology, and to deliver world-class Web3 experiences built on top of Ocean Protocol. An up to date list of our partners and collaborators is maintained on our [main site](https://oceanprotocol.com/collaborators).
 
 If you would like to become a service partner, please get in touch [via the website](https://oceanprotocol.com/collaborators#servicepartner).
 

--- a/building-with-ocean/projects-using-ocean.md
+++ b/building-with-ocean/projects-using-ocean.md
@@ -5,8 +5,6 @@ description: We work with many competent partners who understand the value of Oc
 
 We work closely with our collaborators and service partners to iterate on our underlying technology, and to deliver world-class Web3 experiences built on top of Ocean Protocol. An up to date list of our partners and collaborators is maintained on our [main site](https://oceanprotocol.com/collaborators).
 
-If you would like to become a service partner, please get in touch [via the website](https://oceanprotocol.com/collaborators#servicepartner).
-
 ## Other Useful Information
 
 ### OceanDAO projects

--- a/building-with-ocean/projects-using-ocean.md
+++ b/building-with-ocean/projects-using-ocean.md
@@ -3,19 +3,25 @@ title: Projects using Ocean Protocol
 description: This page helps you to find projects in the Ocean ecosystem.
 ---
 
-## OceanDAO projects
+We work closely with our collaborators and service partners to iterate on the network's underlying technology, and to deliver world-class Web3 experiences built on top of Ocean Protocol to enterprises. An up to date list of our partners and collaborators is maintained on our [main site](https://oceanprotocol.com/collaborators).
+
+If you would like to become a service partner, please get in touch [via the website](https://oceanprotocol.com/collaborators#servicepartner).
+
+## Other Useful Information
+
+### OceanDAO projects
 
 [Ocean Pearl](https://oceanpearl.io/projects) is a great way to browse 80+ Ocean projects that came through [OceanDAO](https://oceanprotocol.com/dao). These projects may be building on the Ocean stack, doing outreach, unlocking data, or more.
 
-## Using Ocean Market
+### Using Ocean Market
 
 [Ocean Market](https://market.oceanprotocol.com) is the best place to find projects that publish datasets. Simply go there and browse the datasets:)
 
-## Learning about Ocean
+### Learning about Ocean
 
 The [Ocean Academy](https://oceanacademy.io/) project is a great way to learn more about Ocean beyond [oceanprotocol.com](https://www.oceanprotocol.com) and [docs.oceanprotocol.com](https://docs.oceanprotocol.com).
 
-## Trading OCEAN
+### Trading OCEAN
 
 The [Coingecko OCEAN markets page](https://www.coingecko.com/en/coins/ocean-protocol#markets) lists forums to exchange OCEAN. Many of them offer liquidity mining and other yield opportunities.
 

--- a/building-with-ocean/projects-using-ocean.md
+++ b/building-with-ocean/projects-using-ocean.md
@@ -1,6 +1,6 @@
 ---
 title: Partners & Collaborators
-description: We work with many competent partners who understand the value of Ocean
+description: We work with many partners who understand the value of Ocean
 ---
 
 We work closely with our collaborators and service partners to iterate on our underlying technology, and to deliver world-class Web3 experiences built on top of Ocean Protocol. An up to date list of our partners and collaborators is maintained on our [main site](https://oceanprotocol.com/collaborators).

--- a/building-with-ocean/projects-using-ocean.md
+++ b/building-with-ocean/projects-using-ocean.md
@@ -1,6 +1,6 @@
 ---
-title: Projects using Ocean Protocol
-description: This page helps you to find projects in the Ocean ecosystem.
+title: Partners & Collaborators
+description: We work with many competent partners who understand the value of Ocean
 ---
 
 We work closely with our collaborators and service partners to iterate on the network's underlying technology, and to deliver world-class Web3 experiences built on top of Ocean Protocol to enterprises. An up to date list of our partners and collaborators is maintained on our [main site](https://oceanprotocol.com/collaborators).


### PR DESCRIPTION
I'm proposing that we just link to the main site rather than maintaining a full list of partners on this page.

Fixes #1151
Fixes #1036 

Changes proposed in this PR:

- Adding information about service partners and link to the main site 
- changing the name and description of the page

[Preview](https://ocean-protocol.gitbook.io/partners-page/building-with-ocean/projects-using-ocean)