### PR TITLE
NFT Owner can call the function set token uri

### DIFF
--- a/core-concepts/roles.md
+++ b/core-concepts/roles.md
@@ -41,7 +41,7 @@ Finally, we also have a fee manager which has the ability to set a new fee colle
 
 | Action &darr; / Role &rarr;       | NFT Owner              | Manager                | ERC20 Deployer         | Store Updater          | Metadata Updater       |
 | --------------------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| Set token URI                     |                        |                        |                        |                        |                        |
+| Set token URI                     | <center>**✓**</center> |                        |                        |                        |                        |
 | Add manager                       | <center>**✓**</center> |                        |                        |                        |                        |
 | Remove manager                    | <center>**✓**</center> |                        |                        |                        |                        |
 | Clean permissions                 | <center>**✓**</center> |                        |                        |                        |                        |


### PR DESCRIPTION
As per ERC721 Template : 
    function setTokenURI(uint256 tokenId, string memory tokenURI) public {
        require(msg.sender == ownerOf(tokenId), "ERC721Template: not NFTOwner");
        _setTokenURI(tokenId, tokenURI);
        emit TokenURIUpdate(msg.sender, tokenURI, tokenId,
            /* solium-disable-next-line */
            block.timestamp,
            block.number);
    }

Fixes # .

Changes proposed in this PR:

- 
- 
- 