### PR TITLE
Fix discord server link

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,6 @@
 ## Community
 
 * [Medium](https://blog.oceanprotocol.com/)
-* [Discord](https://discord.gg/oceanprotocol)
+* [Discord](https://discord.com/invite/TnXjkR5)
 * [Telegram](https://t.me/OceanProtocol\_Community)
 * [Twitter](https://twitter.com/oceanprotocol)


### PR DESCRIPTION
The community discord link is currently pointing to discord/invite/oceanprotocol. This brings potential failing points as the domain is available just in certain conditions.
Replaced it with the invite link we also use on the oceanprotocol website.